### PR TITLE
fix: rename sparkle to bookmark and fix Maestro flows

### DIFF
--- a/.maestro/02_collection_creation_01_create_and_share.yaml
+++ b/.maestro/02_collection_creation_01_create_and_share.yaml
@@ -1,0 +1,84 @@
+appId: com.tamakifujino.nose
+---
+# Test 02-01: Create Collection & Share (User A)
+# Creates a collection, adds a spot, shares with User B.
+
+- launchApp
+
+# Sign in as User A
+- runFlow: shared/login_user_a.yaml
+- runFlow: shared/dismiss_location_permission.yaml
+
+# Search for a place
+- tapOn:
+    id: "search_button"
+- inputText: "Kings Canyon National Park"
+- extendedWaitUntil:
+    visible: "Kings Canyon National Park"
+    timeout: 10000
+# Tap the search result row (index 1), not the search bar text (index 0)
+- tapOn:
+    text: "Kings Canyon National Park"
+    index: 1
+
+# Bookmark the place
+- extendedWaitUntil:
+    visible:
+      id: "bookmark"
+    timeout: 10000
+- tapOn:
+    id: "bookmark"
+- assertVisible: "Save to Collection"
+
+# Create a new collection
+- tapOn:
+    id: "add"
+# Select an icon
+- tapOn:
+    id: "icon_button"
+- extendedWaitUntil:
+    visible: "Hobby"
+    timeout: 10000
+# Tap the first icon in the grid
+- tapOn:
+    id: "icon_cell_0"
+# Type collection name
+- tapOn:
+    id: "collection_name_field"
+- inputText: "National Parks"
+- hideKeyboard
+- tapOn: "Save"
+
+# Save to the collection
+- extendedWaitUntil:
+    visible: "National Parks"
+    timeout: 10000
+- tapOn: "National Parks"
+- tapOn: "Save"
+
+# Dismiss place detail
+- runFlow: shared/dismiss_modal.yaml
+
+# Open collections and verify
+- runFlow: shared/open_collections.yaml
+- assertVisible: "My Collections"
+- tapOn: "National Parks"
+- assertVisible: "Kings Canyon National Park"
+- assertVisible:
+    id: "places_count_label"
+    text: "1"
+
+# Share with User B
+- tapOn: "More"
+- tapOn: "Share with Friends"
+- tapOn: "User B"
+- tapOn: "Update Sharing"
+- assertVisible:
+    id: "shared_friends_count_label"
+    text: "2"
+
+# Dismiss collection detail modal, then collection list modal
+- runFlow: shared/dismiss_modal.yaml
+- runFlow: shared/dismiss_modal.yaml
+- runFlow: shared/logout.yaml
+- assertVisible: "Continue with Google"

--- a/.maestro/02_collection_creation_02_add_spot.yaml
+++ b/.maestro/02_collection_creation_02_add_spot.yaml
@@ -1,0 +1,53 @@
+appId: com.tamakifujino.nose
+---
+# Test 02-02: Add Spot to Shared Collection (User B)
+# User B adds a spot to the shared collection from User A.
+
+- launchApp
+
+# Sign in as User B
+- runFlow: shared/login_user_b.yaml
+- runFlow: shared/dismiss_location_permission.yaml
+
+# Search for a place
+- tapOn:
+    id: "search_button"
+- inputText: "Pinnacles National Park"
+- extendedWaitUntil:
+    visible: "Pinnacles National Park"
+    timeout: 10000
+# Tap the search result row (index 1), not the search bar text (index 0)
+- tapOn:
+    text: "Pinnacles National Park"
+    index: 1
+
+# Bookmark and save to shared collection
+- extendedWaitUntil:
+    visible:
+      id: "bookmark"
+    timeout: 10000
+- tapOn:
+    id: "bookmark"
+- assertVisible: "Save to Collection"
+- tapOn: "From Friends"
+- tapOn: "National Parks"
+- tapOn: "Save"
+
+# Dismiss place detail
+- runFlow: shared/dismiss_modal.yaml
+
+# Verify the collection now has 2 spots
+- runFlow: shared/open_collections.yaml
+- tapOn: "From Friends"
+- tapOn: "National Parks"
+- assertVisible:
+    id: "places_count_label"
+    text: "2"
+- assertVisible: "Kings Canyon National Park"
+- assertVisible: "Pinnacles National Park"
+
+# Dismiss collection detail modal, then collection list modal
+- runFlow: shared/dismiss_modal.yaml
+- runFlow: shared/dismiss_modal.yaml
+- runFlow: shared/logout.yaml
+- assertVisible: "Continue with Google"

--- a/.maestro/99_delete_account_01_delete_user_a.yaml
+++ b/.maestro/99_delete_account_01_delete_user_a.yaml
@@ -1,0 +1,57 @@
+appId: com.tamakifujino.nose
+---
+# Test 99-01: Settings Verification & Delete User A
+
+- launchApp
+
+# Sign in as User A
+- runFlow: shared/login_user_a.yaml
+- runFlow: shared/dismiss_location_permission.yaml
+
+# Open Settings
+- tapOn: "Personal Library"
+
+# Swipe up from bottom of screen to scroll past the avatar header
+- swipe:
+    start: "50%,90%"
+    end: "50%,20%"
+- swipe:
+    start: "50%,90%"
+    end: "50%,20%"
+
+# Verify Privacy Policy page loads
+- tapOn: "Privacy Policy"
+- runFlow: shared/go_back.yaml
+
+# Verify Terms of Service page loads
+- tapOn: "Terms of Service"
+- runFlow: shared/go_back.yaml
+
+# Verify app version
+- assertVisible: "App Version"
+- assertVisible:
+    id: "app_version_text"
+
+# Verify Licenses
+- tapOn: "Licenses"
+- runFlow: shared/go_back.yaml
+
+# Swipe down to scroll back up to Account
+- swipe:
+    start: "50%,20%"
+    end: "50%,90%"
+- swipe:
+    start: "50%,20%"
+    end: "50%,90%"
+
+# Delete account
+- tapOn: "Account"
+- tapOn: "Delete Account"
+- tapOn: "Confirm"
+- tapOn: "Delete"
+- tapOn:
+    text: "OK"
+    optional: true
+
+# Verify returned to login screen
+- assertVisible: "Continue with Google"

--- a/.maestro/99_delete_account_02_delete_user_b.yaml
+++ b/.maestro/99_delete_account_02_delete_user_b.yaml
@@ -1,0 +1,35 @@
+appId: com.tamakifujino.nose
+---
+# Test 99-02: Verify Cascade & Delete User B
+
+- launchApp
+
+# Sign in as User B
+- runFlow: shared/login_user_b.yaml
+- runFlow: shared/dismiss_location_permission.yaml
+
+# Verify User A's collection no longer appears
+- runFlow: shared/open_collections.yaml
+- tapOn: "From Friends"
+- assertNotVisible: "National Parks"
+- runFlow: shared/dismiss_modal.yaml
+- runFlow: shared/dismiss_modal.yaml
+
+# Delete account
+- tapOn: "Personal Library"
+
+# Swipe up from bottom to scroll past avatar header
+- swipe:
+    start: "50%,90%"
+    end: "50%,50%"
+
+- tapOn: "Account"
+- tapOn: "Delete Account"
+- tapOn: "Confirm"
+- tapOn: "Delete"
+- tapOn:
+    text: "OK"
+    optional: true
+
+# Verify returned to login screen
+- assertVisible: "Continue with Google"

--- a/.maestro/shared/open_collections.yaml
+++ b/.maestro/shared/open_collections.yaml
@@ -1,0 +1,5 @@
+appId: com.tamakifujino.nose
+---
+# Navigate to collections: tap bookmark button
+- tapOn:
+    id: "bookmark"

--- a/nose/ViewControllers/03_Home/HomeViewController.swift
+++ b/nose/ViewControllers/03_Home/HomeViewController.swift
@@ -68,7 +68,7 @@ final class HomeViewController: UIViewController {
             target: self,
             backgroundColor: .clear
         )
-        button.accessibilityIdentifier = "sparkle"
+        button.accessibilityIdentifier = "bookmark"
         button.accessibilityLabel = "Collections"
         return button
     }()


### PR DESCRIPTION
## Summary
- Rename the collections button accessibility ID from `sparkle` to `bookmark` to match the actual icon
- Fix Maestro test flows: add missing `dismiss_modal` calls for stacked modals, fix search result tapping with `index: 1`, and use swipe-based scrolling on Settings screen to avoid triggering the avatar tap gesture

## Test plan
- [x] `02_collection_creation_01_create_and_share.yaml` — passed
- [x] `02_collection_creation_02_add_spot.yaml` — passed
- [x] `99_delete_account_01_delete_user_a.yaml` — passed
- [x] `99_delete_account_02_delete_user_b.yaml` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)