### PR TITLE
Add Japanese localization (en/ja)

### DIFF
--- a/InfoPlist/Info.plist
+++ b/InfoPlist/Info.plist
@@ -4,6 +4,11 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>ja</string>
+	</array>
 	<key>CFBundleDisplayName</key>
 	<string></string>
 	<key>CFBundleExecutable</key>

--- a/nose/Assets/Assets.xcassets/place_pin.imageset/Contents.json
+++ b/nose/Assets/Assets.xcassets/place_pin.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "pin.svg",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/nose/Components/Buttons/CustomGlassButton.swift
+++ b/nose/Components/Buttons/CustomGlassButton.swift
@@ -4,9 +4,7 @@ import UIKit
 class CustomGlassButton: UIButton {
 
     // MARK: - Properties
-    private let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterialLight))
-    private let buttonSize: CGFloat = 55  // Standard size for circular buttons
-    private let cornerRadius: CGFloat = 27.5  // Half of buttonSize for perfect round
+    private let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterialLight))
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -19,34 +17,31 @@ class CustomGlassButton: UIButton {
     }
 
     private func setupButton() {
-        // Insert blur background
-        blurView.frame = bounds
-        blurView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        blurView.translatesAutoresizingMaskIntoConstraints = false
         blurView.isUserInteractionEnabled = false
-        blurView.layer.cornerRadius = cornerRadius
         blurView.clipsToBounds = true
         insertSubview(blurView, at: 0)
 
-        // Base styles
-        layer.cornerRadius = cornerRadius
+        NSLayoutConstraint.activate([
+            blurView.topAnchor.constraint(equalTo: topAnchor),
+            blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            blurView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        layer.cornerCurve = .continuous
         clipsToBounds = true
-        backgroundColor = UIColor.firstColor.withAlphaComponent(0.1) // glass background
-        layer.borderColor = UIColor.firstColor.withAlphaComponent(0.3).cgColor
+        backgroundColor = .clear
+        layer.borderColor = UIColor.white.withAlphaComponent(0.35).cgColor
         layer.borderWidth = 1.0
 
-        setTitleColor(.firstColor, for: .normal)
+        setTitleColor(.white, for: .normal)
         titleLabel?.font = AppFonts.bodyBold(18)
 
-        // Enable press animation
         addTarget(self, action: #selector(pressDown), for: [.touchDown, .touchDragEnter])
         addTarget(self, action: #selector(pressUp), for: [.touchUpInside, .touchCancel, .touchDragExit])
-        
-        // Setup size constraints
+
         translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalToConstant: buttonSize),
-            heightAnchor.constraint(equalToConstant: buttonSize)
-        ])
     }
 
     // MARK: - Press Animation
@@ -69,6 +64,8 @@ class CustomGlassButton: UIButton {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        blurView.frame = bounds
+        let radius = min(bounds.width, bounds.height) / 2
+        layer.cornerRadius = radius
+        blurView.layer.cornerRadius = radius
     }
 }

--- a/nose/Components/Cells/PlaceTableViewCell.swift
+++ b/nose/Components/Cells/PlaceTableViewCell.swift
@@ -239,7 +239,7 @@ class PlaceTableViewCell: UITableViewCell {
         placeImageView.image = nil
         
         nameLabel.text = place.name
-        ratingLabel.text = "Rating: \(String(format: "%.1f", place.rating))"
+        ratingLabel.text = String(format: String(localized: "place_rating_format"), String(format: "%.1f", place.rating))
         
         // Update heart button state and visibility
         heartButton.isSelected = isHearted

--- a/nose/Components/Feedback/AlertManager.swift
+++ b/nose/Components/Feedback/AlertManager.swift
@@ -13,7 +13,7 @@ final class AlertManager {
         message: String? = nil,
         style: AlertStyle = .info,
         preferredStyle: UIAlertController.Style = .alert,
-        actions: [UIAlertAction] = [UIAlertAction(title: "OK", style: .default)]
+        actions: [UIAlertAction] = [UIAlertAction(title: String(localized: "modal_ok"), style: .default)]
     ) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: preferredStyle)
         actions.forEach { alert.addAction($0) }

--- a/nose/Components/Feedback/ToastMessages.swift
+++ b/nose/Components/Feedback/ToastMessages.swift
@@ -16,43 +16,44 @@ enum ToastType {
 
 struct ToastMessages {
     // maps - success
-    static let collectionCreated = "Collection created successfully!"
-    static let spotSavedtoCollection = "Spot saved to collection!"
-    static let collectionDeleted = "Collection deleted"
-    static let markSpotVisited = "Spot marked as visited!"
-    static let completedCollection = "Collection completed!"
-    static let collectionShared = "Collection shared successfully!"
-    
+    static var collectionCreated: String { String(localized: "toast_collection_created") }
+    static var spotSavedtoCollection: String { String(localized: "toast_spot_saved_to_collection") }
+    static var collectionDeleted: String { String(localized: "toast_collection_deleted") }
+    static var markSpotVisited: String { String(localized: "toast_mark_spot_visited") }
+    static var completedCollection: String { String(localized: "toast_completed_collection") }
+    static var collectionShared: String { String(localized: "toast_collection_shared") }
+    static var collectionUpdated: String { String(localized: "toast_collection_updated") }
+
     // maps - info
-    static let collectionNotSelected = "No collections selected. Select at least one."
-    static let removeSpotFromCollection = "Spot removed from collection"
-    
+    static var collectionNotSelected: String { String(localized: "toast_collection_not_selected") }
+    static var removeSpotFromCollection: String { String(localized: "toast_remove_spot_from_collection") }
+
     // maps - error
-    static let FailedToGetSpotInfo = "Failed to get spot information. Please try again."
-    
+    static var FailedToGetSpotInfo: String { String(localized: "toast_failed_to_get_spot_info") }
+
     // settings - success
-    static let nameUpdated = "Name updated successfully!"
-    
+    static var nameUpdated: String { String(localized: "toast_name_updated") }
+
     // settings - error
-    static let nameUpdateFailed = "Name update failed. Please try again."
-    
+    static var nameUpdateFailed: String { String(localized: "toast_name_update_failed") }
+
     // friends - success
-    static let friendAdded = "Friend added successfully!"
-    static let userBlocked = "User blocked"
-    static let userUnblocked = "User unblocked"
-    static let userUnfrined = "User Unfriended"
-    
+    static var friendAdded: String { String(localized: "toast_friend_added") }
+    static var userBlocked: String { String(localized: "toast_user_blocked") }
+    static var userUnblocked: String { String(localized: "toast_user_unblocked") }
+    static var userUnfrined: String { String(localized: "toast_user_unfriended") }
+
     // friends - error
-    static let userBlockFailed = "User block failed. Please try again."
-    static let userUnblockFailed = "User unblock failed. Please try again."
-    static let userUnfriendFailed = "User Unfriend failed. Please try again."
-    
+    static var userBlockFailed: String { String(localized: "toast_user_block_failed") }
+    static var userUnblockFailed: String { String(localized: "toast_user_unblock_failed") }
+    static var userUnfriendFailed: String { String(localized: "toast_user_unfriend_failed") }
+
     // avatar - success
-    static let avatarUpdated = "Avatar updated successfully!"
-    static let avatarSaved = "saved avatar successfully"
-    
+    static var avatarUpdated: String { String(localized: "toast_avatar_updated") }
+    static var avatarSaved: String { String(localized: "toast_avatar_saved") }
+
     // avatar - error
-    static let avatarUpdateFailed = "Avatar update failed. Please try again."
-    static let categoriesLoadFailed = "Failed to load categories. Please try again."
-    static let noCategoriesAvailable = "No categories available. Please check your connection."
+    static var avatarUpdateFailed: String { String(localized: "toast_avatar_update_failed") }
+    static var categoriesLoadFailed: String { String(localized: "toast_categories_load_failed") }
+    static var noCategoriesAvailable: String { String(localized: "toast_no_categories_available") }
 }

--- a/nose/Components/Modals/ConfirmationModalViewController.swift
+++ b/nose/Components/Modals/ConfirmationModalViewController.swift
@@ -52,7 +52,7 @@ class ConfirmationModalViewController: UIViewController {
         message: String,
         primaryTitle: String,
         primaryStyle: PrimaryStyle = .default,
-        cancelTitle: String = "Cancel",
+        cancelTitle: String = String(localized: "modal_cancel"),
         onPrimary: @escaping () -> Void,
         onCancel: (() -> Void)? = nil
     ) {

--- a/nose/Components/Modals/MessageModalViewController.swift
+++ b/nose/Components/Modals/MessageModalViewController.swift
@@ -50,7 +50,7 @@ class MessageModalViewController: UIViewController {
     }()
     
     // MARK: - Initialization
-    init(title: String, message: String, buttonTitle: String = "OK") {
+    init(title: String, message: String, buttonTitle: String = String(localized: "modal_ok")) {
         self.titleText = title
         self.messageText = message
         self.buttonTitle = buttonTitle

--- a/nose/InfoPlist.xcstrings
+++ b/nose/InfoPlist.xcstrings
@@ -1,0 +1,69 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nose"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nose"
+          }
+        }
+      }
+    },
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "nose"
+          }
+        }
+      }
+    },
+    "NSLocationAlwaysUsageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Always allow"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常に許可"
+          }
+        }
+      }
+    },
+    "NSLocationWhenInUseUsageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow when using the app"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリ使用中は位置情報を許可"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/nose/Localizable.xcstrings
+++ b/nose/Localizable.xcstrings
@@ -1,19 +1,36 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "app_name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nose"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nose"
+          }
+        }
+      }
+    },
     "apple_login" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "    Continue with Apple Account"
+            "value" : "Continue with Apple"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "    Appleアカウントで続ける"
+            "value" : "Appleで続ける"
           }
         }
       }
@@ -24,13 +41,200 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "    Continue with Google Account"
+            "value" : "Continue with Google"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "    Googleアカウントで続ける"
+            "value" : "Googleで続ける"
+          }
+        }
+      }
+    },
+    "login_terms_base" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "By continuing, you agree to\nour "
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続行すると、次のことに同意したことになります\n"
+          }
+        }
+      }
+    },
+    "login_terms_of_service" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terms of Service"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用規約"
+          }
+        }
+      }
+    },
+    "login_terms_and" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " and "
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "および"
+          }
+        }
+      }
+    },
+    "login_privacy_policy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy Policy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシーポリシー"
+          }
+        }
+      }
+    },
+    "login_terms_end" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "。"
+          }
+        }
+      }
+    },
+    "modal_error_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
+          }
+        }
+      }
+    },
+    "login_error_check_user" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to check user status. Please try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー状態の確認に失敗しました。もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "login_error_google_config" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google Sign-In is not properly configured. Please try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Googleサインインの設定に問題があります。もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "login_error_google_credentials" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to get Google authentication credentials. Please try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google認証情報の取得に失敗しました。もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "login_error_google_signin_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to sign in with Google: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Googleでサインインできませんでした：%@"
+          }
+        }
+      }
+    },
+    "login_error_firebase_auth_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to authenticate with Firebase: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Firebase認証に失敗しました：%@"
           }
         }
       }
@@ -68,7 +272,624 @@
           }
         }
       }
-    }
+    },
+    "toast_collection_created" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Collection created successfully!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを作成しました！" } }
+      }
+    },
+    "toast_spot_saved_to_collection" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Spot saved to collection!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スポットをコレクションに保存しました！" } }
+      }
+    },
+    "toast_collection_deleted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Collection deleted" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを削除しました" } }
+      }
+    },
+    "toast_mark_spot_visited" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Spot marked as visited!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スポットを訪問済みにしました！" } }
+      }
+    },
+    "toast_completed_collection" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Collection completed!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを完了しました！" } }
+      }
+    },
+    "toast_collection_shared" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Collection shared successfully!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを共有しました！" } }
+      }
+    },
+    "toast_collection_not_selected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No collections selected. Select at least one." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションが選択されていません。1つ以上選択してください。" } }
+      }
+    },
+    "toast_remove_spot_from_collection" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Spot removed from collection" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スポットをコレクションから削除しました" } }
+      }
+    },
+    "toast_failed_to_get_spot_info" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to get spot information. Please try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スポット情報の取得に失敗しました。もう一度お試しください。" } }
+      }
+    },
+    "toast_name_updated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Name updated successfully!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前を更新しました！" } }
+      }
+    },
+    "toast_name_update_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Name update failed. Please try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前の更新に失敗しました。もう一度お試しください。" } }
+      }
+    },
+    "toast_friend_added" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Friend added successfully!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達を追加しました！" } }
+      }
+    },
+    "toast_user_blocked" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "User blocked" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーをブロックしました" } }
+      }
+    },
+    "toast_user_unblocked" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "User unblocked" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロックを解除しました" } }
+      }
+    },
+    "toast_user_unfriended" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "User Unfriended" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達解除しました" } }
+      }
+    },
+    "toast_user_block_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "User block failed. Please try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロックに失敗しました。もう一度お試しください。" } }
+      }
+    },
+    "toast_user_unblock_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "User unblock failed. Please try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロック解除に失敗しました。もう一度お試しください。" } }
+      }
+    },
+    "toast_user_unfriend_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "User Unfriend failed. Please try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達解除に失敗しました。もう一度お試しください。" } }
+      }
+    },
+    "toast_avatar_updated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Avatar updated successfully!" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アバターを更新しました！" } }
+      }
+    },
+    "toast_avatar_saved" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "saved avatar successfully" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アバターを保存しました" } }
+      }
+    },
+    "toast_avatar_update_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Avatar update failed. Please try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アバターの更新に失敗しました。もう一度お試しください。" } }
+      }
+    },
+    "toast_categories_load_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to load categories. Please try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "カテゴリの読み込みに失敗しました。もう一度お試しください。" } }
+      }
+    },
+    "toast_no_categories_available" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No categories available. Please check your connection." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "カテゴリがありません。接続を確認してください。" } }
+      }
+    },
+    "modal_ok" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "OK" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "OK" } } }
+    },
+    "modal_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "キャンセル" } } }
+    },
+    "button_save" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Save" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存" } } }
+    },
+    "button_add" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Add" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "追加" } } }
+    },
+    "save_to_collection_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Save to Collection" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションに保存" } } }
+    },
+    "save_saving" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Saving..." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存中..." } } }
+    },
+    "save_already_saved_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Already Saved" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存済み" } } }
+    },
+    "save_already_saved_message" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This place is already saved in this collection." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このスポットは既にこのコレクションに保存されています。" } } }
+    },
+    "save_failed_place" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to save place. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "スポットの保存に失敗しました。もう一度お試しください。" } } }
+    },
+    "save_failed_event" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to save event. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの保存に失敗しました。もう一度お試しください。" } } }
+    },
+    "edit_collection_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Edit Collection" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを編集" } } }
+    },
+    "button_saving" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Saving..." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存中..." } } }
+    },
+    "error_user_not_authenticated" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "User not authenticated" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーが認証されていません" } } }
+    },
+    "error_failed_update_collection" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to update collection. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションの更新に失敗しました。もう一度お試しください。" } } }
+    },
+    "collection_modal_select_icon" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Select an icon" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アイコンを選択" } } }
+    },
+    "collection_modal_enter_name" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter a name" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前を入力" } } }
+    },
+    "collections_empty_personal" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Your favorite spots deserve a home.\nTap + to create your first collection!" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "お気に入りのスポットをまとめよう。\n+ をタップして最初のコレクションを作成！" } } }
+    },
+    "collections_empty_shared" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No shared collections yet.\nAsk your friends to invite you to theirs!\n\nYou can add friends in\nSettings > Add Friends" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "共有コレクションはまだありません。\n友達に招待してもらいましょう！\n\n友達は 設定 > 友達を追加 で追加できます" } } }
+    },
+    "collections_my_collections" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "My Collections" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "マイコレクション" } } }
+    },
+    "collections_your_collections" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Your Collections" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "あなたのコレクション" } } }
+    },
+    "collections_from_friends" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "From Friends" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達から" } } }
+    },
+    "place_opening_hours" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Opening Hours" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "営業時間" } } }
+    },
+    "place_hours_not_available" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Opening hours not available" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "営業時間の情報がありません" } } }
+    },
+    "place_phone_not_available" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Phone number not available" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "電話番号がありません" } } }
+    },
+    "button_customize_avatar" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Customize avatar" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アバターをカスタマイズ" } } }
+    },
+    "toast_please_sign_in_to_heart" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Please sign in to heart spots" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "スポットにハートするにはサインインしてください" } } }
+    },
+    "toast_only_members_can_heart" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Only collection members can heart spots" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションメンバーのみスポットにハートできます" } } }
+    },
+    "toast_failed_to_save_hearts" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to save hearts" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ハートの保存に失敗しました" } } }
+    },
+    "toast_collection_updated" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Collection updated" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを更新しました" } } }
+    },
+    "loading_sharing_collection" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Sharing Collection..." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを共有中..." } } }
+    },
+    "toast_failed_to_share_collection" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to share collection" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションの共有に失敗しました" } } }
+    },
+    "toast_collection_shared_success" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Collection shared successfully" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを共有しました" } } }
+    },
+    "alert_unable_to_load_details" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Unable to Load Details" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "詳細を読み込めませんでした" } } }
+    },
+    "alert_could_not_load_details_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Could not load complete details for %@. Please try again later." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ の詳細を読み込めませんでした。後でもう一度お試しください。" } } }
+    },
+    "action_open_in" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Open in" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "で開く" } } }
+    },
+    "action_copy" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コピー" } } }
+    },
+    "action_delete" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "削除" } } }
+    },
+    "home_location_unavailable_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Location Unavailable" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "位置情報を利用できません" } } }
+    },
+    "home_location_unavailable_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Enable location in Settings to use this feature" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "この機能を使うには設定で位置情報を有効にしてください" } } }
+    },
+    "home_coming_soon_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Coming Soon" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "近日公開" } } }
+    },
+    "home_coming_soon_message" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This feature is coming soon!" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "この機能は近日公開予定です！" } } }
+    },
+    "edit_name_char_count" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "%d/%d" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%d/%d" } } }
+    },
+    "edit_name_failed_load" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to load user data: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーデータの読み込みに失敗しました：%@" } } }
+    },
+    "edit_name_invalid_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Invalid Name" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "無効な名前" } } }
+    },
+    "edit_name_enter_valid" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Please enter a valid name" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "有効な名前を入力してください" } } }
+    },
+    "edit_name_min_length_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Name must be at least %d characters long" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前は%d文字以上にしてください" } } }
+    },
+    "edit_name_max_length_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Name must be no more than %d characters long" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前は%d文字以内にしてください" } } }
+    },
+    "edit_name_success_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Success" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "完了" } } }
+    },
+    "edit_name_success_message" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Name updated successfully" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前を更新しました" } } }
+    },
+    "edit_name_failed_update_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to update name: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前の更新に失敗しました：%@" } } }
+    },
+    "add_friend_your_user_id" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Your User ID:" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "あなたのユーザーID：" } } }
+    },
+    "add_friend_send_request" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Send Request" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "リクエストを送信" } } }
+    },
+    "add_friend_invalid_input" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Please enter a User ID to search" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "検索するユーザーIDを入力してください" } } }
+    },
+    "add_friend_invalid_user_id" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "User ID must be exactly 10 characters (letters and numbers)" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーIDは10文字（英数字）で入力してください" } } }
+    },
+    "add_friend_cannot_add_yourself" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "You cannot add yourself as a friend" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "自分自身を友達に追加することはできません" } } }
+    },
+    "add_friend_search_error" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "An error occurred while searching. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "検索中にエラーが発生しました。もう一度お試しください。" } } }
+    },
+    "add_friend_user_not_found" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No user found with this User ID. Please check the ID and try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このユーザーIDのユーザーが見つかりません。IDを確認してもう一度お試しください。" } } }
+    },
+    "add_friend_blocked_user" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "You have blocked this user. Please unblock them first to add them as a friend." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このユーザーをブロックしています。友達に追加するには先にブロックを解除してください。" } } }
+    },
+    "add_friend_already_friends" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This user is already in your friends list" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このユーザーは既に友達リストにいます" } } }
+    },
+    "add_friend_request_pending" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This user has already sent you a friend request. Check the Pending tab to approve or reject." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このユーザーから既に友達リクエストが届いています。保留タブで承認または拒否してください。" } } }
+    },
+    "add_friend_request_already_sent" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "You have already sent a friend request to this user. Check the Pending tab." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このユーザーには既に友達リクエストを送信しています。保留タブを確認してください。" } } }
+    },
+    "add_friend_request_sent_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Request Sent!" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "リクエストを送信しました！" } } }
+    },
+    "add_friend_request_sent_message" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Wait for the friend to approve the request." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達がリクエストを承認するまでお待ちください。" } } }
+    },
+    "add_friend_send_request_failed" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to send friend request. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達リクエストの送信に失敗しました。もう一度お試しください。" } } }
+    },
+    "friends_approve" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Approve" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "承認" } } }
+    },
+    "friends_reject" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Reject" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "拒否" } } }
+    },
+    "friends_block_confirm_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Block user?" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーをブロックしますか？" } } }
+    },
+    "friends_block_confirm_message_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Are you sure you want to block \"%@\"? You will not be able to share a collection or add them as a friend." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "\"%@\" をブロックしてもよろしいですか？コレクションの共有や友達追加ができなくなります。" } } }
+    },
+    "friends_unblock_confirm_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Unblock user?" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロックを解除しますか？" } } }
+    },
+    "friends_unblock_confirm_message_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ will be able to add you as a friend with your User ID." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ があなたのユーザーIDで友達追加できるようになります。" } } }
+    },
+    "friends_block_success" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "User blocked successfully" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーをブロックしました" } } }
+    },
+    "friends_block_failed_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to block user: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロックに失敗しました：%@" } } }
+    },
+    "friends_unblock_success" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "User unblocked successfully" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロックを解除しました" } } }
+    },
+    "friends_unblock_failed_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to unblock user: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロック解除に失敗しました：%@" } } }
+    },
+    "friends_requested" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "%@ requested" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ がリクエスト" } } }
+    },
+    "friends_approve_confirm_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Approve request" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "リクエストを承認" } } }
+    },
+    "friends_approve_confirm_message_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Add %@ as a friend?" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ を友達に追加しますか？" } } }
+    },
+    "friends_approve_success" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Friend request approved." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達リクエストを承認しました。" } } }
+    },
+    "friends_reject_confirm_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Reject request" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "リクエストを拒否" } } }
+    },
+    "friends_reject_confirm_message_format" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Reject friend request from %@?" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ からの友達リクエストを拒否しますか？" } } }
+    },
+    "friends_block_user" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Block User" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーをブロック" } } }
+    },
+    "friends_unblock_user" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Unblock User" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロックを解除" } } }
+    },
+    "modal_success_title" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Success" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "完了" } } }
+    },
+    "add_friend_cannot_add_friend" : {
+      "extractionState" : "manual",
+      "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Cannot Add Friend" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達に追加できません" } } }
+    },
+    "settings_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Settings" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "設定" } } } },
+    "settings_profile" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Profile" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "プロフィール" } } } },
+    "settings_name" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Name" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前" } } } },
+    "settings_account" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Account" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アカウント" } } } },
+    "settings_friends" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Friends" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達" } } } },
+    "settings_friend_list" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Friend List" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達リスト" } } } },
+    "settings_add_friend" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Add Friend" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達を追加" } } } },
+    "settings_about" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "About" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このアプリについて" } } } },
+    "settings_privacy_policy" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Privacy Policy" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライバシーポリシー" } } } },
+    "settings_terms_of_service" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Terms of Service" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "利用規約" } } } },
+    "settings_app_version" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "App Version" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アプリバージョン" } } } },
+    "settings_licenses" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Licenses" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ライセンス" } } } },
+    "friends_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Friends" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達" } } } },
+    "friends_tab_pending" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Pending" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "保留" } } } },
+    "friends_tab_requested" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Requested" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "リクエスト済み" } } } },
+    "friends_tab_blocked" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Blocked" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロック中" } } } },
+    "friends_empty_friends" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No friends yet. Share your User ID from Add Friend so others can send you a request." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "まだ友達はいません。友達を追加からユーザーIDを共有すると、リクエストが届きます。" } } } },
+    "friends_empty_pending" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No pending requests. When someone sends you a friend request, it will appear here." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "保留中のリクエストはありません。友達リクエストが届くとここに表示されます。" } } } },
+    "friends_empty_requested" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No requests sent. When you send a friend request from Add Friend, it will appear here until they respond." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "送信したリクエストはありません。友達を追加からリクエストを送ると、相手が返答するまでここに表示されます。" } } } },
+    "friends_empty_blocked" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No blocked users." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロックしているユーザーはいません。" } } } },
+    "add_friend_search_placeholder" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Search by User ID" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーIDで検索" } } } },
+    "add_friend_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Add Friend" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達を追加" } } } },
+    "edit_name_placeholder" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter your name" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前を入力" } } } },
+    "edit_name_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Edit Name" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前を編集" } } } },
+    "collection_modal_name_placeholder" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Collection Name" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクション名" } } } },
+    "search_placeholder" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Search for places" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "スポットを検索" } } } },
+    "account_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Account" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アカウント" } } } },
+    "account_logged_out_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Logged Out" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ログアウトしました" } } } },
+    "account_logged_out_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "You have been successfully logged out." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ログアウトしました。" } } } },
+    "account_logout_failed_format" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to log out: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ログアウトに失敗しました：%@" } } } },
+    "account_deleted_success" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Account deleted successfully" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アカウントを削除しました" } } } },
+    "account_delete_failed_format" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to delete account: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アカウントの削除に失敗しました：%@" } } } },
+    "account_logout_confirm_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Are you sure you want to log out?" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ログアウトしてもよろしいですか？" } } } },
+    "account_delete_confirm_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete Account" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アカウントを削除" } } } },
+    "account_delete_confirm_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Are you sure you want to delete your account? This action cannot be undone." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アカウントを削除してもよろしいですか？この操作は取り消せません。" } } } },
+    "button_delete" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "削除" } } } },
+    "button_confirm" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Confirm" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "確認" } } } },
+    "account_logout_row" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Logout" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ログアウト" } } } },
+    "account_delete_account_row" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete Account" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アカウントを削除" } } } },
+    "account_logout_confirm_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Log Out" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ログアウト" } } } },
+    "account_delete_confirm_short" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This action is irreversible. Are you sure?" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "この操作は取り消せません。よろしいですか？" } } } },
+    "error_failed_load_content" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to load content. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コンテンツの読み込みに失敗しました。もう一度お試しください。" } } } },
+    "licenses_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Licenses" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ライセンス" } } } },
+    "profile_select_picture_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Profile Picture" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "プロフィール写真を選択" } } } },
+    "profile_no_avatar_found" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No avatar images found" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "アバター画像が見つかりません" } } } },
+    "name_registration_prompt" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "What should we call you?" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "お名前を教えてください" } } } },
+    "new_collection_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "New Collection" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "新規コレクション" } } } },
+    "share_collection_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Share Collection" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを共有" } } } },
+    "share_collection_description" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Shared users can save spots to this collection, but cannot add friends or delete the collection." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "共有されたユーザーはこのコレクションにスポットを保存できますが、友達の追加やコレクションの削除はできません。" } } } },
+    "share_collection_will_remove" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Will be removed" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "解除されます" } } } },
+    "share_collection_will_add" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Will be added" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "追加されます" } } } },
+    "event_detail_no_details" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No additional details" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "詳細なし" } } } },
+    "events_upcoming" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Upcoming Events" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "今後のイベント" } } } },
+    "events_past" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Past Events" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "過去のイベント" } } } },
+    "action_visited" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Visited" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "訪問済み" } } } },
+    "action_unvisited" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Unvisited" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "未訪問" } } } },
+    "place_rating_format" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Rating: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "評価: %@" } } } },
+    "home_personal_library" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Personal Library" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "パーソナルライブラリ" } } } },
+    "deeplink_error_resolve" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Could not resolve the link." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "リンクを解決できませんでした。" } } } },
+    "deeplink_cannot_open_no_place" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This link doesn't include a recognizable place." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このリンクに認識できるスポットが含まれていません。" } } } },
+    "deeplink_resolved_no_place" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "The resolved link doesn't include a recognizable place." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "解決したリンクに認識できるスポットが含まれていません。" } } } },
+    "deeplink_place_not_found" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Could not find a matching place." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "一致するスポットが見つかりませんでした。" } } } },
+    "deeplink_place_no_details" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Could not find details for this place." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このスポットの詳細が見つかりませんでした。" } } } },
+    "deeplink_error_open_map" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Could not open the map." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "マップを開けませんでした。" } } } },
+    "deeplink_sign_in_required" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Please sign in to add this collection." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このコレクションを追加するにはサインインしてください。" } } } },
+    "deeplink_already_owned" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This is your own collection." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "これはあなた自身のコレクションです。" } } } },
+    "deeplink_error_check_collection" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to check collection. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションの確認に失敗しました。もう一度お試しください。" } } } },
+    "deeplink_collection_not_found" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This collection could not be found." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このコレクションが見つかりませんでした。" } } } },
+    "deeplink_error_load_collection" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to load collection data." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションデータの読み込みに失敗しました。" } } } },
+    "deeplink_collection_unavailable" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "This collection is no longer available." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "このコレクションは利用できなくなりました。" } } } },
+    "deeplink_error_add_collection" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to add collection. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションの追加に失敗しました。もう一度お試しください。" } } } },
+    "deeplink_error_open_collection" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to open collection. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを開けませんでした。もう一度お試しください。" } } } },
+    "deeplink_error_open_collection_generic" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Could not open the collection." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションを開けませんでした。" } } } },
+    "deeplink_map_moved_address_format" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Map moved to %@. You can search for places nearby." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "マップを %@ に移動しました。近くのスポットを検索できます。" } } } },
+    "deeplink_map_moved_shared" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Map moved to shared location. You can search for places nearby." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "マップを共有場所に移動しました。近くのスポットを検索できます。" } } } },
+    "deeplink_friend_required_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Friend Required" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "友達登録が必要です" } } } },
+    "deeplink_friend_required_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "To join the collection, you need to be friend with the collection owner." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "コレクションに参加するには、コレクションの所有者と友達になる必要があります。" } } } },
+    "toast_joined_collection_format" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "You joined the collection created by %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ が作成したコレクションに参加しました" } } } },
+    "event_title_label" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Title" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "タイトル" } } } },
+    "event_title_placeholder" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter title (max 25 characters)" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "タイトルを入力（25文字以内）" } } } },
+    "event_date_time_label" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Date & Time" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "日時" } } } },
+    "event_from_label" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "From" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "開始" } } } },
+    "event_to_label" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "To" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "終了" } } } },
+    "event_duration_format" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Duration: %@" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "所要時間: %@" } } } },
+    "event_location_label" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Location" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "場所" } } } },
+    "event_location_placeholder" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Search for location" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "場所を検索" } } } },
+    "event_details_label" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Details" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "詳細" } } } },
+    "event_details_placeholder" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe the event... (max 1000 characters)" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの説明を入力...（1000文字以内）" } } } },
+    "event_images_label" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Images" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "画像" } } } },
+    "event_upload_one_image" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Upload 1 image" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "画像を1枚アップロード" } } } },
+    "event_loading" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Loading..." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "読み込み中..." } } } },
+    "event_char_count_format" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "%d/%d" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "%d/%d" } } } },
+    "event_error_not_authenticated" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "User not authenticated" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "ユーザーが認証されていません" } } } },
+    "event_error_check_events" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to check existing events. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "既存のイベントの確認に失敗しました。もう一度お試しください。" } } } },
+    "event_error_create_failed" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to create event. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの作成に失敗しました。もう一度お試しください。" } } } },
+    "event_error_update_failed" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to update event. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの更新に失敗しました。もう一度お試しください。" } } } },
+    "event_validation_missing_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Missing Title" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "タイトルが入力されていません" } } } },
+    "event_validation_missing_title_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Please enter an event title." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントのタイトルを入力してください。" } } } },
+    "event_validation_title_too_long" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Title Too Long" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "タイトルが長すぎます" } } } },
+    "event_validation_title_max_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Event title must be 25 characters or less." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "タイトルは25文字以内で入力してください。" } } } },
+    "event_validation_missing_location" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Missing Location" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "場所が選択されていません" } } } },
+    "event_validation_missing_location_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Please select an event location." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの場所を選択してください。" } } } },
+    "event_validation_missing_details" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Missing Details" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "詳細が入力されていません" } } } },
+    "event_validation_missing_details_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Please enter event details." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの詳細を入力してください。" } } } },
+    "event_validation_details_too_long" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Details Too Long" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "詳細が長すぎます" } } } },
+    "event_validation_details_max_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Event details must be 1000 characters or less." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "詳細は1000文字以内で入力してください。" } } } },
+    "manage_events_empty_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No events yet" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "まだイベントはありません" } } } },
+    "manage_events_empty_subtitle" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Tap + to create your first event" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "+ をタップして最初のイベントを作成" } } } },
+    "manage_events_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "My Events" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "マイイベント" } } } },
+    "manage_events_error_load" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to load events. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの読み込みに失敗しました。もう一度お試しください。" } } } },
+    "manage_events_error_delete" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Failed to delete event. Please try again." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントの削除に失敗しました。もう一度お試しください。" } } } },
+    "event_creating" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Creating Event" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントを作成中" } } } },
+    "event_updating" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Updating Event" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベントを更新中" } } } },
+    "event_limit_reached_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Event Limit Reached" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "イベント数の上限に達しました" } } } },
+    "event_limit_reached_message" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "You can only create one event at a time." } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "一度に作成できるイベントは1つまでです。" } } } },
+    "date_picker_start_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Start Date & Time" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "開始日時を選択" } } } },
+    "date_picker_end_title" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Select End Date & Time" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "終了日時を選択" } } } },
+    "button_select" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Select" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "選択" } } } },
+    "unity_colors" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "Colors" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "カラー" } } } },
+    "unity_no_assets" : { "extractionState" : "manual", "localizations" : { "en" : { "stringUnit" : { "state" : "translated", "value" : "No assets available" } }, "ja" : { "stringUnit" : { "state" : "translated", "value" : "利用可能なアセットがありません" } } } }
   },
   "version" : "1.0"
 }

--- a/nose/Managers/Navigation/DeepLinkManager.swift
+++ b/nose/Managers/Navigation/DeepLinkManager.swift
@@ -67,7 +67,7 @@ final class DeepLinkManager {
                                     Logger.log("Resolved to: \(resolved.absoluteString)", level: .info, category: "DeepLink")
                                     self.processResolvedURL(resolved, in: window)
                                 } else {
-                                    self.showAlert(title: "Error", message: "Could not resolve the link.", in: window)
+                                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_resolve"), in: window)
                                 }
                             }
                         }
@@ -84,7 +84,7 @@ final class DeepLinkManager {
         }
         
         Logger.log("No recognizable content in URL", level: .warn, category: "DeepLink")
-        showAlert(title: "Cannot Open Link", message: "This link doesn't include a recognizable place.", in: window)
+        showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_cannot_open_no_place"), in: window)
         return false
     }
     
@@ -275,7 +275,7 @@ final class DeepLinkManager {
             Logger.log("Searching for place by query: \(query)", level: .info, category: "DeepLink")
             searchForPlaceByName(query, in: window)
         } else {
-            showAlert(title: "Cannot Open Link", message: "The resolved link doesn't include a recognizable place.", in: window)
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_resolved_no_place"), in: window)
         }
     }
     
@@ -309,13 +309,13 @@ final class DeepLinkManager {
                                     self.openPlaceInApp(placeId: retryResult.placeID, in: window)
                                 } else {
                                     Logger.log("No places found for query or fallback", level: .warn, category: "DeepLink")
-                                    self.showAlert(title: "Place Not Found", message: "Could not find a matching place.", in: window)
+                                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_place_not_found"), in: window)
                                 }
                             }
                         }
                     } else {
                         Logger.log("No places found for query", level: .warn, category: "DeepLink")
-                        self.showAlert(title: "Place Not Found", message: "Could not find a matching place.", in: window)
+                        self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_place_not_found"), in: window)
                     }
                 }
             }
@@ -368,7 +368,7 @@ final class DeepLinkManager {
                     self.showPlaceInMap(place: place, in: window)
                 } else {
                     Logger.log("Failed to fetch place details", level: .warn, category: "DeepLink")
-                    self.showAlert(title: "Place Not Found", message: "Could not find details for this place.", in: window)
+                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_place_no_details"), in: window)
                 }
             }
         }
@@ -377,7 +377,7 @@ final class DeepLinkManager {
     private func showPlaceInMap(place: GMSPlace, in window: UIWindow?) {
         // Find or create HomeViewController
         guard let homeVC = findOrCreateHomeViewController(in: window) else {
-            showAlert(title: "Error", message: "Could not open the map.", in: window)
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_open_map"), in: window)
             return
         }
         
@@ -391,7 +391,7 @@ final class DeepLinkManager {
     
     private func openCoordinateInApp(latitude: Double, longitude: Double, in window: UIWindow?) {
         guard let homeVC = findOrCreateHomeViewController(in: window) else {
-            showAlert(title: "Error", message: "Could not open the map.", in: window)
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_open_map"), in: window)
             return
         }
         
@@ -408,13 +408,13 @@ final class DeepLinkManager {
         
         // Ensure user is authenticated
         guard let currentUserId = Auth.auth().currentUser?.uid else {
-            showAlert(title: "Sign In Required", message: "Please sign in to add this collection.", in: window)
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_sign_in_required"), in: window)
             return
         }
         
         // Don't allow adding your own collection
         if currentUserId == userId {
-            showAlert(title: "Already Owned", message: "This is your own collection.", in: window)
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_already_owned"), in: window)
             return
         }
         
@@ -428,7 +428,7 @@ final class DeepLinkManager {
             
             if let error = error {
                 Logger.log("Error checking existing collection: \(error.localizedDescription)", level: .error, category: "DeepLink")
-                self.showAlert(title: "Error", message: "Failed to check collection. Please try again.", in: window)
+                self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_check_collection"), in: window)
                 return
             }
             
@@ -448,25 +448,25 @@ final class DeepLinkManager {
                 
                 if let error = error {
                     Logger.log("Error fetching collection: \(error.localizedDescription)", level: .error, category: "DeepLink")
-                    self.showAlert(title: "Collection Not Found", message: "This collection could not be found.", in: window)
+                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_collection_not_found"), in: window)
                     return
                 }
                 
                 guard let ownerData = ownerSnapshot?.data(),
                       ownerSnapshot?.exists == true else {
-                    self.showAlert(title: "Collection Not Found", message: "This collection could not be found.", in: window)
+                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_collection_not_found"), in: window)
                     return
                 }
                 
                 // Parse the collection
                 guard let collection = PlaceCollection(dictionary: ownerData) else {
-                    self.showAlert(title: "Error", message: "Failed to load collection data.", in: window)
+                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_load_collection"), in: window)
                     return
                 }
                 
                 // Check if collection is active
                 guard collection.status == .active else {
-                    self.showAlert(title: "Collection Unavailable", message: "This collection is no longer available.", in: window)
+                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_collection_unavailable"), in: window)
                     return
                 }
                 
@@ -525,7 +525,7 @@ final class DeepLinkManager {
                         if let error = error {
                             DispatchQueue.main.async {
                                 Logger.log("Error adding collection: \(error.localizedDescription)", level: .error, category: "DeepLink")
-                                self.showAlert(title: "Error", message: "Failed to add collection. Please try again.", in: window)
+                                self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_add_collection"), in: window)
                             }
                         } else {
                             Logger.log("Successfully added collection: \(collection.name)", level: .info, category: "DeepLink")
@@ -534,7 +534,7 @@ final class DeepLinkManager {
                             guard let sharedCollection = PlaceCollection(dictionary: sharedCollectionData) else {
                                 DispatchQueue.main.async {
                                     Logger.log("Failed to create shared collection object", level: .error, category: "DeepLink")
-                                    self.showAlert(title: "Error", message: "Failed to open collection. Please try again.", in: window)
+                                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_open_collection"), in: window)
                                 }
                                 return
                             }
@@ -554,7 +554,7 @@ final class DeepLinkManager {
                                     
                                     // Show toast message
                                     ToastManager.showToast(
-                                        message: "You joined the collection created by \(ownerName)",
+                                        message: String(format: String(localized: "toast_joined_collection_format"), ownerName),
                                         type: .success
                                     )
                                     
@@ -589,16 +589,16 @@ final class DeepLinkManager {
             
             DispatchQueue.main.async {
                 let alert = UIAlertController(
-                    title: "Friend Required",
-                    message: "To join the collection, you need to be friend with the collection owner.",
+                    title: String(localized: "deeplink_friend_required_title"),
+                    message: String(localized: "deeplink_friend_required_message"),
                     preferredStyle: .alert
                 )
                 
                 // OK button
-                alert.addAction(UIAlertAction(title: "OK", style: .default))
+                alert.addAction(UIAlertAction(title: String(localized: "modal_ok"), style: .default))
                 
                 // Add Friend button
-                alert.addAction(UIAlertAction(title: "Add Friend", style: .default) { [weak self] _ in
+                alert.addAction(UIAlertAction(title: String(localized: "settings_add_friend"), style: .default) { [weak self] _ in
                     self?.navigateToAddFriend(ownerUserId: ownerUserIdString, in: window)
                 })
                 
@@ -656,7 +656,7 @@ final class DeepLinkManager {
         DispatchQueue.main.async {
             // Find or create HomeViewController
             guard let homeVC = self.findOrCreateHomeViewController(in: window) else {
-                self.showAlert(title: "Error", message: "Could not open the collection.", in: window)
+                self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "deeplink_error_open_collection_generic"), in: window)
                 return
             }
             
@@ -758,9 +758,9 @@ final class DeepLinkManager {
     private func showLocationSharedMessage(address: String?, in window: UIWindow?) {
         let message: String
         if let address = address {
-            message = "Map moved to \(address). You can search for places nearby."
+            message = String(format: String(localized: "deeplink_map_moved_address_format"), address)
         } else {
-            message = "Map moved to shared location. You can search for places nearby."
+            message = String(localized: "deeplink_map_moved_shared")
         }
         Logger.log("Showing location shared message: \(message)", level: .info, category: "DeepLink")
         // Note: We show the message but don't block the UI

--- a/nose/ViewControllers/Event/CreateEventViewController+Delegates.swift
+++ b/nose/ViewControllers/Event/CreateEventViewController+Delegates.swift
@@ -9,7 +9,7 @@ extension CreateEventViewController: UITextFieldDelegate {
             let newText = (currentText as NSString).replacingCharacters(in: range, with: string)
 
             if newText.count <= 25 {
-                titleCharCountLabel.text = "\(newText.count)/25"
+                titleCharCountLabel.text = String(format: String(localized: "event_char_count_format"), newText.count, 25)
                 titleCharCountLabel.textColor = newText.count > 20 ? .systemRed : .secondaryLabel
                 return true
             }
@@ -55,7 +55,7 @@ extension CreateEventViewController: UITextViewDelegate {
         detailsPlaceholderLabel.isHidden = !textView.text.isEmpty
 
         let count = textView.text.count
-        detailsCharCountLabel.text = "\(count)/1000"
+        detailsCharCountLabel.text = String(format: String(localized: "event_char_count_format"), count, 1000)
         detailsCharCountLabel.textColor = count > 900 ? .systemRed : .secondaryLabel
 
         if count > 1000 {
@@ -76,7 +76,7 @@ extension CreateEventViewController: UITableViewDelegate, UITableViewDataSource 
         // Safety check to prevent index out of bounds crash
         guard indexPath.row < locationPredictions.count else {
             var content = cell.defaultContentConfiguration()
-            content.text = "Loading..."
+            content.text = String(localized: "event_loading")
             cell.contentConfiguration = content
             return cell
         }

--- a/nose/ViewControllers/Event/CreateEventViewController.swift
+++ b/nose/ViewControllers/Event/CreateEventViewController.swift
@@ -73,7 +73,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var titleSectionLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Title"
+        label.text = String(localized: "event_title_label")
         label.font = .systemFont(ofSize: 18, weight: .semibold)
         label.textColor = .label
         return label
@@ -82,7 +82,7 @@ final class CreateEventViewController: UIViewController {
     lazy var titleTextField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.placeholder = "Enter title (max 25 characters)"
+        textField.placeholder = String(localized: "event_title_placeholder")
         textField.borderStyle = .roundedRect
         textField.font = .systemFont(ofSize: 16)
         textField.delegate = self
@@ -92,7 +92,7 @@ final class CreateEventViewController: UIViewController {
     lazy var titleCharCountLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "0/25"
+        label.text = String(format: String(localized: "event_char_count_format"), 0, 25)
         label.font = .systemFont(ofSize: 12)
         label.textColor = .secondaryLabel
         label.textAlignment = .right
@@ -103,7 +103,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var dateTimeSectionLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Date & Time"
+        label.text = String(localized: "event_date_time_label")
         label.font = .systemFont(ofSize: 18, weight: .semibold)
         label.textColor = .label
         return label
@@ -112,7 +112,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var startDateLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "From"
+        label.text = String(localized: "event_from_label")
         label.font = .systemFont(ofSize: 16, weight: .medium)
         label.textColor = .label
         return label
@@ -136,7 +136,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var endDateLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "To"
+        label.text = String(localized: "event_to_label")
         label.font = .systemFont(ofSize: 16, weight: .medium)
         label.textColor = .label
         return label
@@ -160,7 +160,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var durationDisplayLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Duration: 1h"
+        label.text = String(format: String(localized: "event_duration_format"), "1h")
         label.font = .systemFont(ofSize: 14, weight: .medium)
         label.textColor = .fourthColor
         label.textAlignment = .center
@@ -173,7 +173,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var locationSectionLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Location"
+        label.text = String(localized: "event_location_label")
         label.font = .systemFont(ofSize: 18, weight: .semibold)
         label.textColor = .label
         return label
@@ -182,7 +182,7 @@ final class CreateEventViewController: UIViewController {
     lazy var locationTextField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.placeholder = "Search for location"
+        textField.placeholder = String(localized: "event_location_placeholder")
         textField.borderStyle = .roundedRect
         textField.font = .systemFont(ofSize: 16)
         textField.delegate = self
@@ -209,7 +209,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var detailsSectionLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Details"
+        label.text = String(localized: "event_details_label")
         label.font = .systemFont(ofSize: 18, weight: .semibold)
         label.textColor = .label
         return label
@@ -230,7 +230,7 @@ final class CreateEventViewController: UIViewController {
     lazy var detailsPlaceholderLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Describe the event... (max 1000 characters)"
+        label.text = String(localized: "event_details_placeholder")
         label.font = .systemFont(ofSize: 16)
         label.textColor = .placeholderText
         return label
@@ -239,7 +239,7 @@ final class CreateEventViewController: UIViewController {
     lazy var detailsCharCountLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "0/1000"
+        label.text = String(format: String(localized: "event_char_count_format"), 0, 1000)
         label.font = .systemFont(ofSize: 12)
         label.textColor = .secondaryLabel
         label.textAlignment = .right
@@ -250,7 +250,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var imagesSectionLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Images"
+        label.text = String(localized: "event_images_label")
         label.font = .systemFont(ofSize: 18, weight: .semibold)
         label.textColor = .label
         return label
@@ -259,7 +259,7 @@ final class CreateEventViewController: UIViewController {
     private lazy var imagesLimitLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Upload 1 image"
+        label.text = String(localized: "event_upload_one_image")
         label.font = .systemFont(ofSize: 14)
         label.textColor = .secondaryLabel
         return label
@@ -501,7 +501,7 @@ final class CreateEventViewController: UIViewController {
         
         // Populate title
         titleTextField.text = event.title
-        titleCharCountLabel.text = "\(event.title.count)/25"
+        titleCharCountLabel.text = String(format: String(localized: "event_char_count_format"), event.title.count, 25)
         
         // Populate dates
         selectedStartDate = event.dateTime.startDate
@@ -516,7 +516,7 @@ final class CreateEventViewController: UIViewController {
         // Populate details
         detailsTextView.text = event.details
         detailsPlaceholderLabel.isHidden = !event.details.isEmpty
-        detailsCharCountLabel.text = "\(event.details.count)/1000"
+        detailsCharCountLabel.text = String(format: String(localized: "event_char_count_format"), event.details.count, 1000)
         
         // Populate images
         selectedImages = event.images
@@ -586,7 +586,7 @@ final class CreateEventViewController: UIViewController {
     
     private func createEvent() {
         guard let userId = Auth.auth().currentUser?.uid else {
-            showAlert(title: "Error", message: "User not authenticated")
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "event_error_not_authenticated"))
             return
         }
         
@@ -599,8 +599,8 @@ final class CreateEventViewController: UIViewController {
                 if count >= 1 {
                     DispatchQueue.main.async {
                         self.showAlert(
-                            title: "Event Limit Reached",
-                            message: "You can only create one event at a time."
+                            title: String(localized: "event_limit_reached_title"),
+                            message: String(localized: "event_limit_reached_message")
                         )
                     }
                     return
@@ -613,7 +613,7 @@ final class CreateEventViewController: UIViewController {
                 
             case .failure(let error):
                 DispatchQueue.main.async {
-                    self.showAlert(title: "Error", message: "Failed to check existing events. Please try again.")
+                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "event_error_check_events"))
                     Logger.log("Error checking upcoming events: \(error.localizedDescription)", level: .error, category: "CreateEvent")
                 }
             }
@@ -622,7 +622,7 @@ final class CreateEventViewController: UIViewController {
     
     private func proceedWithEventCreation(userId: String) {
         // Show loading indicator
-        showLoadingAlert(title: "Creating Event")
+        showLoadingAlert(title: String(localized: "event_creating"))
         
         let eventDateTime = EventDateTime(startDate: selectedStartDate, endDate: selectedEndDate)
         let event = Event(
@@ -657,7 +657,7 @@ final class CreateEventViewController: UIViewController {
                 case .failure(let error):
                     Logger.log("Failed to create event: \(error.localizedDescription)", level: .error, category: "CreateEvent")
                     self?.dismiss(animated: true) {
-                        self?.showAlert(title: "Error", message: "Failed to create event. Please try again.")
+                        self?.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "event_error_create_failed"))
                     }
                 }
             }
@@ -668,7 +668,7 @@ final class CreateEventViewController: UIViewController {
         guard let eventToEdit = eventToEdit else { return }
         
         // Show loading indicator
-        showLoadingAlert(title: "Updating Event")
+        showLoadingAlert(title: String(localized: "event_updating"))
         
         let eventDateTime = EventDateTime(startDate: selectedStartDate, endDate: selectedEndDate)
         let updatedEvent = Event(
@@ -696,7 +696,7 @@ final class CreateEventViewController: UIViewController {
                 case .failure(let error):
                     Logger.log("Failed to update event: \(error.localizedDescription)", level: .error, category: "CreateEvent")
                     self?.dismiss(animated: true) {
-                        self?.showAlert(title: "Error", message: "Failed to update event. Please try again.")
+                        self?.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "event_error_update_failed"))
                     }
                 }
             }
@@ -755,7 +755,7 @@ final class CreateEventViewController: UIViewController {
             datePicker.date = selectedEndDate
         }
         
-        let alert = UIAlertController(title: type == .start ? "Select Start Date & Time" : "Select End Date & Time", message: "\n\n\n\n\n\n\n\n\n\n\n", preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: type == .start ? String(localized: "date_picker_start_title") : String(localized: "date_picker_end_title"), message: "\n\n\n\n\n\n\n\n\n\n\n", preferredStyle: .actionSheet)
         
         // Add date picker as subview to the alert's view
         alert.view.addSubview(datePicker)
@@ -768,7 +768,7 @@ final class CreateEventViewController: UIViewController {
             datePicker.heightAnchor.constraint(equalToConstant: 200)
         ])
         
-        let selectAction = UIAlertAction(title: "Select", style: .default) { [weak self] _ in
+        let selectAction = UIAlertAction(title: String(localized: "button_select"), style: .default) { [weak self] _ in
             if type == .start {
                 self?.selectedStartDate = datePicker.date
                 // Ensure end date is after start date
@@ -782,7 +782,7 @@ final class CreateEventViewController: UIViewController {
             self?.updateDurationDisplay()
         }
         
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        let cancelAction = UIAlertAction(title: String(localized: "modal_cancel"), style: .cancel)
         
         alert.addAction(selectAction)
         alert.addAction(cancelAction)
@@ -807,7 +807,7 @@ final class CreateEventViewController: UIViewController {
     
     private func updateDurationDisplay() {
         let eventDateTime = EventDateTime(startDate: selectedStartDate, endDate: selectedEndDate)
-        durationDisplayLabel.text = "Duration: \(eventDateTime.formattedDuration)"
+        durationDisplayLabel.text = String(format: String(localized: "event_duration_format"), eventDateTime.formattedDuration)
     }
     
     func searchLocations(query: String) {
@@ -878,27 +878,27 @@ extension CreateEventViewController {
     // MARK: - Helper Methods
     private func validateForm() -> Bool {
         guard let title = titleTextField.text, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            showAlert(title: "Missing Title", message: "Please enter an event title.")
+            showAlert(title: String(localized: "event_validation_missing_title"), message: String(localized: "event_validation_missing_title_message"))
             return false
         }
         
         guard title.count <= 25 else {
-            showAlert(title: "Title Too Long", message: "Event title must be 25 characters or less.")
+            showAlert(title: String(localized: "event_validation_title_too_long"), message: String(localized: "event_validation_title_max_message"))
             return false
         }
         
         guard selectedLocation != nil else {
-            showAlert(title: "Missing Location", message: "Please select an event location.")
+            showAlert(title: String(localized: "event_validation_missing_location"), message: String(localized: "event_validation_missing_location_message"))
             return false
         }
         
         guard let details = detailsTextView.text, !details.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            showAlert(title: "Missing Details", message: "Please enter event details.")
+            showAlert(title: String(localized: "event_validation_missing_details"), message: String(localized: "event_validation_missing_details_message"))
             return false
         }
         
         guard details.count <= 1000 else {
-            showAlert(title: "Details Too Long", message: "Event details must be 1000 characters or less.")
+            showAlert(title: String(localized: "event_validation_details_too_long"), message: String(localized: "event_validation_details_max_message"))
             return false
         }
         

--- a/nose/ViewControllers/Event/ManageEventViewController.swift
+++ b/nose/ViewControllers/Event/ManageEventViewController.swift
@@ -59,14 +59,14 @@ class ManageEventViewController: UIViewController {
         
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "No events yet"
+        label.text = String(localized: "manage_events_empty_title")
         label.font = .systemFont(ofSize: 18, weight: .medium)
         label.textColor = .secondaryLabel
         label.textAlignment = .center
         
         let subtitleLabel = UILabel()
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        subtitleLabel.text = "Tap + to create your first event"
+        subtitleLabel.text = String(localized: "manage_events_empty_subtitle")
         subtitleLabel.font = .systemFont(ofSize: 14)
         subtitleLabel.textColor = .tertiaryLabel
         subtitleLabel.textAlignment = .center
@@ -121,7 +121,7 @@ class ManageEventViewController: UIViewController {
     
     private func setupUI() {
         view.backgroundColor = .systemBackground
-        title = "My Events"
+        title = String(localized: "manage_events_title")
         
         // Add navigation bar buttons
         let backButton = UIBarButtonItem(
@@ -184,7 +184,7 @@ class ManageEventViewController: UIViewController {
     private func loadEvents() {
         guard !isLoading else { return }
         guard let userId = Auth.auth().currentUser?.uid else {
-            showAlert(title: "Error", message: "User not authenticated")
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "event_error_not_authenticated"))
             return
         }
         
@@ -205,7 +205,7 @@ class ManageEventViewController: UIViewController {
                     self?.updateAddButtonState()
                 case .failure(let error):
                     Logger.log("Failed to load events: \(error.localizedDescription)", level: .error, category: "ManageEvent")
-                    self?.showAlert(title: "Error", message: "Failed to load events. Please try again.")
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "manage_events_error_load"))
                     self?.updateUI()
                     self?.updateAddButtonState()
                 }
@@ -374,7 +374,7 @@ extension ManageEventViewController: UITableViewDelegate, UITableViewDataSource 
                     ToastManager.showToast(message: "Event deleted", type: .success)
                 case .failure(let error):
                     Logger.log("Failed to delete event: \(error.localizedDescription)", level: .error, category: "ManageEvent")
-                    self?.showAlert(title: "Error", message: "Failed to delete event. Please try again.")
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "manage_events_error_delete"))
                 }
             }
         }

--- a/nose/ViewControllers/Home/Collection/CollectionModalViewController.swift
+++ b/nose/ViewControllers/Home/Collection/CollectionModalViewController.swift
@@ -27,7 +27,7 @@ class CollectionModalViewController: UIViewController, UITextFieldDelegate {
     
     let iconSelectionLabel: UILabel = {
         let label = UILabel()
-        label.text = "Select an icon"
+        label.text = String(localized: "collection_modal_select_icon")
         label.font = .systemFont(ofSize: 16)
         label.textColor = .label
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -47,13 +47,13 @@ class CollectionModalViewController: UIViewController, UITextFieldDelegate {
         button.addTarget(self, action: #selector(iconButtonTapped), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.accessibilityIdentifier = "icon_button"
-        button.accessibilityLabel = "Select an icon"
+        button.accessibilityLabel = String(localized: "collection_modal_select_icon")
         return button
     }()
     
     let nameLabel: UILabel = {
         let label = UILabel()
-        label.text = "Enter a name"
+        label.text = String(localized: "collection_modal_enter_name")
         label.font = .systemFont(ofSize: 16)
         label.textColor = .label
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -62,7 +62,7 @@ class CollectionModalViewController: UIViewController, UITextFieldDelegate {
     
     lazy var nameTextField: UITextField = {
         let textField = UITextField()
-        textField.placeholder = "Collection Name"
+        textField.placeholder = String(localized: "collection_modal_name_placeholder")
         textField.font = .systemFont(ofSize: 16)
         textField.borderStyle = .none
         textField.backgroundColor = UIColor.systemGray5 // Match icon button color
@@ -83,7 +83,7 @@ class CollectionModalViewController: UIViewController, UITextFieldDelegate {
     
     lazy var cancelButton: CustomButton = {
         let button = CustomButton(type: .system)
-        button.setTitle("Cancel", for: .normal)
+        button.setTitle(String(localized: "modal_cancel"), for: .normal)
         button.style = .secondary
         button.size = .medium
         button.isPerfectlyRounded = true
@@ -97,7 +97,7 @@ class CollectionModalViewController: UIViewController, UITextFieldDelegate {
 
     lazy var saveButton: CustomButton = {
         let button = CustomButton(type: .system)
-        button.setTitle("Save", for: .normal)
+        button.setTitle(String(localized: "button_save"), for: .normal)
         button.style = .primary
         button.size = .medium
         button.isPerfectlyRounded = true

--- a/nose/ViewControllers/Home/Collection/CollectionPlacesViewController+Delegates.swift
+++ b/nose/ViewControllers/Home/Collection/CollectionPlacesViewController+Delegates.swift
@@ -25,7 +25,7 @@ extension CollectionPlacesViewController: EditCollectionModalViewControllerDeleg
                 self.currentIconName = updatedCollection.iconName
                 self.updateCollectionIconDisplay()
                 NotificationCenter.default.post(name: NSNotification.Name("RefreshCollections"), object: nil)
-                ToastManager.showToast(message: "Collection updated", type: .success)
+                ToastManager.showToast(message: ToastMessages.collectionUpdated, type: .success)
             case .failure(let error):
                 Logger.log("Error fetching updated collection: \(error.localizedDescription)", level: .error, category: "Collection")
             }
@@ -37,7 +37,7 @@ extension CollectionPlacesViewController: EditCollectionModalViewControllerDeleg
 
 extension CollectionPlacesViewController: ShareCollectionViewControllerDelegate {
     func shareCollectionViewController(_ controller: ShareCollectionViewController, didSelectFriends friends: [User]) {
-        LoadingView.shared.showOverlayLoading(on: view, message: "Sharing Collection...")
+        LoadingView.shared.showOverlayLoading(on: view, message: String(localized: "loading_sharing_collection"))
 
         CollectionContainerManager.shared.shareCollection(collection, with: friends) { [weak self] error in
             DispatchQueue.main.async {
@@ -45,9 +45,9 @@ extension CollectionPlacesViewController: ShareCollectionViewControllerDelegate 
 
                 if let error = error {
                     Logger.log("Error sharing collection: \(error.localizedDescription)", level: .error, category: "Collection")
-                    ToastManager.showToast(message: "Failed to share collection", type: .error)
+                    ToastManager.showToast(message: String(localized: "toast_failed_to_share_collection"), type: .error)
                 } else {
-                    ToastManager.showToast(message: "Collection shared successfully", type: .success)
+                    ToastManager.showToast(message: String(localized: "toast_collection_shared_success"), type: .success)
                     self?.loadSharedFriendsCount()
                 }
             }

--- a/nose/ViewControllers/Home/Collection/CollectionPlacesViewController+TableView.swift
+++ b/nose/ViewControllers/Home/Collection/CollectionPlacesViewController+TableView.swift
@@ -29,11 +29,11 @@ extension CollectionPlacesViewController: UITableViewDelegate, UITableViewDataSo
             let hasPastEvents = !pastEvents.isEmpty
 
             if hasFutureEvents && hasPastEvents {
-                return section == 0 ? "Upcoming Events" : "Past Events"
+                return section == 0 ? String(localized: "events_upcoming") : String(localized: "events_past")
             } else if hasFutureEvents {
-                return "Upcoming Events"
+                return String(localized: "events_upcoming")
             } else if hasPastEvents {
-                return "Past Events"
+                return String(localized: "events_past")
             }
             return nil
         }
@@ -120,8 +120,8 @@ extension CollectionPlacesViewController: UITableViewDelegate, UITableViewDataSo
                 } else {
                     DispatchQueue.main.async {
                         let messageModal = MessageModalViewController(
-                            title: "Unable to Load Details",
-                            message: "Could not load complete details for \(place.name). Please try again later."
+                            title: String(localized: "alert_unable_to_load_details"),
+                            message: String(format: String(localized: "alert_could_not_load_details_format"), place.name)
                         )
                         self?.present(messageModal, animated: true)
                     }
@@ -158,28 +158,28 @@ extension CollectionPlacesViewController: UITableViewDelegate, UITableViewDataSo
                 return UISwipeActionsConfiguration(actions: [])
             }
             let place = places[indexPath.row]
-            let mapAction = UIContextualAction(style: .normal, title: "Open in") { [weak self] (action, view, completion) in
+            let mapAction = UIContextualAction(style: .normal, title: String(localized: "action_open_in")) { [weak self] (action, view, completion) in
                 self?.openPlaceInMapsByName(place.name)
                 completion(true)
             }
             mapAction.backgroundColor = .blueColor
             mapAction.image = UIImage(systemName: "arrow.up.forward")
 
-            let visitedAction = UIContextualAction(style: .normal, title: place.visited ? "Unvisited" : "Visited") { [weak self] (action, view, completion) in
+            let visitedAction = UIContextualAction(style: .normal, title: place.visited ? String(localized: "action_unvisited") : String(localized: "action_visited")) { [weak self] (action, view, completion) in
                 self?.toggleVisitedStatus(at: indexPath)
                 completion(true)
             }
             visitedAction.backgroundColor = .blueColor
             visitedAction.image = UIImage(systemName: place.visited ? "xmark.circle" : "checkmark.circle")
 
-            let copyAction = UIContextualAction(style: .normal, title: "Copy") { [weak self] (action, view, completion) in
+            let copyAction = UIContextualAction(style: .normal, title: String(localized: "action_copy")) { [weak self] (action, view, completion) in
                 self?.showCopyOptions(for: place, at: indexPath)
                 completion(true)
             }
             copyAction.backgroundColor = .blueColor
             copyAction.image = UIImage(systemName: "doc.on.doc")
 
-            let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] (action, view, completion) in
+            let deleteAction = UIContextualAction(style: .destructive, title: String(localized: "action_delete")) { [weak self] (action, view, completion) in
                 self?.confirmDeletePlace(at: indexPath)
                 completion(false)
             }
@@ -200,7 +200,7 @@ extension CollectionPlacesViewController: UITableViewDelegate, UITableViewDataSo
             return UISwipeActionsConfiguration(actions: [])
         }
 
-        let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] (action, view, completion) in
+        let deleteAction = UIContextualAction(style: .destructive, title: String(localized: "action_delete")) { [weak self] (action, view, completion) in
             self?.confirmDeleteEvent(at: indexPath)
             completion(false)
         }

--- a/nose/ViewControllers/Home/Collection/CollectionPlacesViewController.swift
+++ b/nose/ViewControllers/Home/Collection/CollectionPlacesViewController.swift
@@ -164,7 +164,7 @@ class CollectionPlacesViewController: UIViewController, UIGestureRecognizerDeleg
     lazy var customizeButton: CustomButton = {
         let button = CustomButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Customize avatar", for: .normal)
+        button.setTitle(String(localized: "button_customize_avatar"), for: .normal)
         button.style = .themeBlue
         button.size = .medium
         button.isPerfectlyRounded = true
@@ -495,13 +495,13 @@ class CollectionPlacesViewController: UIViewController, UIGestureRecognizerDeleg
     
     func toggleHeart(for placeId: String, isHearted: Bool) {
         guard let currentUserId = Auth.auth().currentUser?.uid else {
-            ToastManager.showToast(message: "Please sign in to heart spots", type: .error)
+            ToastManager.showToast(message: String(localized: "toast_please_sign_in_to_heart"), type: .error)
             return
         }
         
         // Check if user is a member of this collection
         guard collectionMembers.contains(currentUserId) else {
-            ToastManager.showToast(message: "Only collection members can heart spots", type: .error)
+            ToastManager.showToast(message: String(localized: "toast_only_members_can_heart"), type: .error)
             return
         }
         
@@ -555,7 +555,7 @@ class CollectionPlacesViewController: UIViewController, UIGestureRecognizerDeleg
         ) { [weak self] error in
             if let error = error {
                 Logger.log("Error saving hearts: \(error.localizedDescription)", level: .error, category: "Collection")
-                ToastManager.showToast(message: "Failed to save hearts", type: .error)
+                ToastManager.showToast(message: String(localized: "toast_failed_to_save_hearts"), type: .error)
                 self?.loadPlaceHearts()
             }
         }

--- a/nose/ViewControllers/Home/Collection/CollectionsViewController.swift
+++ b/nose/ViewControllers/Home/Collection/CollectionsViewController.swift
@@ -83,7 +83,7 @@ class CollectionsViewController: UIViewController {
 
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Your favorite spots deserve a home.\nTap + to create your first collection!"
+        label.text = String(localized: "collections_empty_personal")
         label.font = .systemFont(ofSize: 16, weight: .medium)
         label.textColor = .thirdColor
         label.textAlignment = .center
@@ -119,7 +119,7 @@ class CollectionsViewController: UIViewController {
 
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "No shared collections yet.\nAsk your friends to invite you to theirs!\n\nYou can add friends in\nSettings > Add Friends"
+        label.text = String(localized: "collections_empty_shared")
         label.font = .systemFont(ofSize: 16, weight: .medium)
         label.textColor = .thirdColor
         label.textAlignment = .center
@@ -146,7 +146,7 @@ class CollectionsViewController: UIViewController {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "My Collections"
+        label.text = String(localized: "collections_my_collections")
         label.font = .systemFont(ofSize: 20, weight: .bold)
         label.textColor = .label
         return label
@@ -292,7 +292,7 @@ class CollectionsViewController: UIViewController {
     
     // MARK: - Tab Management
     private func setupCategoryTabs() {
-        let tabs: [(CollectionTab, String)] = [(.personal, "Your Collections"), (.shared, "From Friends")]
+        let tabs: [(CollectionTab, String)] = [(.personal, String(localized: "collections_your_collections")), (.shared, String(localized: "collections_from_friends"))]
         for (index, (tab, title)) in tabs.enumerated() {
             let button = createTabButton(title: title, tag: index, tab: tab)
             categoryTabStackView.addArrangedSubview(button)

--- a/nose/ViewControllers/Home/Collection/EditCollectionModalViewController.swift
+++ b/nose/ViewControllers/Home/Collection/EditCollectionModalViewController.swift
@@ -23,7 +23,7 @@ class EditCollectionModalViewController: CollectionModalViewController {
     
     // MARK: - Configuration
     override func configureInitialState() {
-        titleLabel.text = "Edit Collection"
+        titleLabel.text = String(localized: "edit_collection_title")
         
         // Load current collection data
         collectionName = collection.name
@@ -61,7 +61,7 @@ class EditCollectionModalViewController: CollectionModalViewController {
         // Show loading indicator
         saveButton.isEnabled = false
         let originalTitle = saveButton.title(for: .normal)
-        saveButton.setTitle("Saving...", for: .normal)
+        saveButton.setTitle(String(localized: "button_saving"), for: .normal)
         
         updateCollection(name: collectionName, iconUrl: selectedIconUrl, iconName: selectedIconName)
     }
@@ -69,8 +69,8 @@ class EditCollectionModalViewController: CollectionModalViewController {
     private func updateCollection(name: String, iconUrl: String?, iconName: String?) {
         guard let currentUserId = Auth.auth().currentUser?.uid else {
             saveButton.isEnabled = true
-            saveButton.setTitle("Save", for: .normal)
-            let messageModal = MessageModalViewController(title: "Error", message: "User not authenticated")
+            saveButton.setTitle(String(localized: "button_save"), for: .normal)
+            let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "error_user_not_authenticated"))
             present(messageModal, animated: true)
             return
         }
@@ -115,7 +115,7 @@ class EditCollectionModalViewController: CollectionModalViewController {
         guard !updateData.isEmpty else {
             // Nothing to update
             saveButton.isEnabled = true
-            saveButton.setTitle("Save", for: .normal)
+            saveButton.setTitle(String(localized: "button_save"), for: .normal)
             dismiss(animated: true)
             return
         }
@@ -129,12 +129,12 @@ class EditCollectionModalViewController: CollectionModalViewController {
                 guard let self = self else { return }
                 DispatchQueue.main.async {
                     self.saveButton.isEnabled = true
-                    self.saveButton.setTitle("Save", for: .normal)
+                    self.saveButton.setTitle(String(localized: "button_save"), for: .normal)
                 }
                 if let error = error {
                     Logger.log("Error fetching members for collection update: \(error.localizedDescription)", level: .error, category: "Collection")
                     DispatchQueue.main.async {
-                        let messageModal = MessageModalViewController(title: "Error", message: "Failed to update collection. Please try again.")
+                        let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "error_failed_update_collection"))
                         self.present(messageModal, animated: true)
                     }
                     return
@@ -148,10 +148,10 @@ class EditCollectionModalViewController: CollectionModalViewController {
                     DispatchQueue.main.async {
                         guard let self = self else { return }
                         self.saveButton.isEnabled = true
-                        self.saveButton.setTitle("Save", for: .normal)
+                        self.saveButton.setTitle(String(localized: "button_save"), for: .normal)
                         if let error = error {
                             Logger.log("Error updating collection: \(error.localizedDescription)", level: .error, category: "Collection")
-                            let messageModal = MessageModalViewController(title: "Error", message: "Failed to update collection. Please try again.")
+                            let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "error_failed_update_collection"))
                             self.present(messageModal, animated: true)
                             return
                         }
@@ -168,10 +168,10 @@ class EditCollectionModalViewController: CollectionModalViewController {
                 DispatchQueue.main.async {
                     guard let self = self else { return }
                     self.saveButton.isEnabled = true
-                    self.saveButton.setTitle("Save", for: .normal)
+                    self.saveButton.setTitle(String(localized: "button_save"), for: .normal)
                     if let error = error {
                         Logger.log("Error updating collection: \(error.localizedDescription)", level: .error, category: "Collection")
-                        let messageModal = MessageModalViewController(title: "Error", message: "Failed to update collection. Please try again.")
+                        let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "error_failed_update_collection"))
                         self.present(messageModal, animated: true)
                         return
                     }

--- a/nose/ViewControllers/Home/Collection/NewCollectionModalViewController.swift
+++ b/nose/ViewControllers/Home/Collection/NewCollectionModalViewController.swift
@@ -18,7 +18,7 @@ class NewCollectionModalViewController: CollectionModalViewController {
     
     // MARK: - Configuration
     override func configureInitialState() {
-        titleLabel.text = "New Collection"
+        titleLabel.text = String(localized: "new_collection_title")
         // Save button starts disabled (handled by base class)
     }
     

--- a/nose/ViewControllers/Home/Collection/ShareCollectionViewController.swift
+++ b/nose/ViewControllers/Home/Collection/ShareCollectionViewController.swift
@@ -22,7 +22,7 @@ final class ShareCollectionViewController: UIViewController {
         label.font = .systemFont(ofSize: 14)
         label.textColor = .secondaryLabel
         label.numberOfLines = 0
-        label.text = "Shared users can save spots to this collection, but cannot add friends or delete the collection."
+        label.text = String(localized: "share_collection_description")
         return label
     }()
     
@@ -67,7 +67,7 @@ final class ShareCollectionViewController: UIViewController {
     // MARK: - Setup
     private func setupUI() {
         view.backgroundColor = .systemBackground
-        title = "Share Collection"
+        title = String(localized: "share_collection_title")
         
         // Add close button
         let closeButton = UIBarButtonItem(
@@ -280,10 +280,10 @@ final class FriendSelectionCell: UITableViewCell {
         checkmarkImageView.isHidden = !isSelected
         
         if wasPreviouslyShared && !isSelected {
-            statusLabel.text = "Will be removed"
+            statusLabel.text = String(localized: "share_collection_will_remove")
             statusLabel.textColor = .systemRed
         } else if !wasPreviouslyShared && isSelected {
-            statusLabel.text = "Will be added"
+            statusLabel.text = String(localized: "share_collection_will_add")
             statusLabel.textColor = .systemGreen
         } else {
             statusLabel.text = wasPreviouslyShared ? "Currently shared" : "Not shared"

--- a/nose/ViewControllers/Home/Event/EventDetailViewController.swift
+++ b/nose/ViewControllers/Home/Event/EventDetailViewController.swift
@@ -225,7 +225,7 @@ final class EventDetailViewController: UIViewController {
         if !event.details.isEmpty {
             detailsLabel.text = event.details
         } else {
-            detailsLabel.text = "No additional details"
+            detailsLabel.text = String(localized: "event_detail_no_details")
             detailsLabel.textColor = .systemGray
         }
     }

--- a/nose/ViewControllers/Home/HomeViewController.swift
+++ b/nose/ViewControllers/Home/HomeViewController.swift
@@ -46,7 +46,7 @@ final class HomeViewController: UIViewController {
             backgroundColor: .clear
         )
         button.accessibilityIdentifier = "personal_library"
-        button.accessibilityLabel = "Personal Library"
+        button.accessibilityLabel = String(localized: "home_personal_library")
         return button
     }()
     
@@ -515,7 +515,7 @@ final class HomeViewController: UIViewController {
             locationManager.requestWhenInUseAuthorization()
         case .denied, .restricted:
             // Show a gentle message that location is not available
-            showMessage(title: "Location Unavailable", subtitle: "Enable location in Settings to use this feature")
+            showMessage(title: String(localized: "home_location_unavailable_title"), subtitle: String(localized: "home_location_unavailable_subtitle"))
         @unknown default:
             break
         }
@@ -560,8 +560,8 @@ final class HomeViewController: UIViewController {
     
     @objc private func createEventButtonTapped() {
         let messageModal = MessageModalViewController(
-            title: "Coming Soon",
-            message: "This feature is coming soon!"
+            title: String(localized: "home_coming_soon_title"),
+            message: String(localized: "home_coming_soon_message")
         )
         present(messageModal, animated: true)
     }

--- a/nose/ViewControllers/Home/Place/PlaceDetailViewController.swift
+++ b/nose/ViewControllers/Home/Place/PlaceDetailViewController.swift
@@ -95,7 +95,7 @@ final class PlaceDetailViewController: UIViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = .systemFont(ofSize: 16)
         label.textColor = .fourthColor
-        label.text = place.phoneNumber ?? "Phone number not available"
+        label.text = place.phoneNumber ?? String(localized: "place_phone_not_available")
         label.numberOfLines = 0
         return label
     }()
@@ -117,7 +117,7 @@ final class PlaceDetailViewController: UIViewController {
         stackView.spacing = 8
         
         let titleLabel = UILabel()
-        titleLabel.text = "Opening Hours"
+        titleLabel.text = String(localized: "place_opening_hours")
         titleLabel.font = .systemFont(ofSize: 18, weight: .semibold)
         
         stackView.addArrangedSubview(titleLabel)
@@ -131,7 +131,7 @@ final class PlaceDetailViewController: UIViewController {
             }
         } else {
             let noHoursLabel = UILabel()
-            noHoursLabel.text = "Opening hours not available"
+            noHoursLabel.text = String(localized: "place_hours_not_available")
             noHoursLabel.font = .systemFont(ofSize: 14)
             noHoursLabel.textColor = .systemGray
             stackView.addArrangedSubview(noHoursLabel)
@@ -366,13 +366,13 @@ final class PlaceDetailViewController: UIViewController {
         ratingView.addArrangedSubview(ratingLabel)
         
         // Update phone number
-        phoneNumberLabel.text = place.phoneNumber ?? "Phone number not available"
+        phoneNumberLabel.text = place.phoneNumber ?? String(localized: "place_phone_not_available")
         
         // Update opening hours
         openingHoursView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
         let titleLabel = UILabel()
-        titleLabel.text = "Opening Hours"
+        titleLabel.text = String(localized: "place_opening_hours")
         titleLabel.font = .systemFont(ofSize: 18, weight: .semibold)
         openingHoursView.addArrangedSubview(titleLabel)
         
@@ -385,7 +385,7 @@ final class PlaceDetailViewController: UIViewController {
             }
         } else {
             let noHoursLabel = UILabel()
-            noHoursLabel.text = "Opening hours not available"
+            noHoursLabel.text = String(localized: "place_hours_not_available")
             noHoursLabel.font = .systemFont(ofSize: 14)
             noHoursLabel.textColor = .systemGray
             openingHoursView.addArrangedSubview(noHoursLabel)

--- a/nose/ViewControllers/Home/Place/SaveToCollectionViewController.swift
+++ b/nose/ViewControllers/Home/Place/SaveToCollectionViewController.swift
@@ -50,7 +50,7 @@ class SaveToCollectionViewController: UIViewController {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "Save to Collection"
+        label.text = String(localized: "save_to_collection_title")
         label.font = .systemFont(ofSize: 24, weight: .bold)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -115,13 +115,13 @@ class SaveToCollectionViewController: UIViewController {
         button.addTarget(self, action: #selector(createNewCollectionTapped), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.accessibilityIdentifier = "add"
-        button.accessibilityLabel = "Add"
+        button.accessibilityLabel = String(localized: "button_add")
         return button
     }()
     
     private lazy var saveButton: CustomButton = {
         let button = CustomButton()
-        button.setTitle("Save", for: .normal)
+        button.setTitle(String(localized: "button_save"), for: .normal)
         button.style = .themeBlue
         button.size = .large
         button.isPerfectlyRounded = true
@@ -400,7 +400,7 @@ class SaveToCollectionViewController: UIViewController {
     
     // MARK: - Tab Management
     private func setupCategoryTabs() {
-        let tabs: [(CollectionTab, String)] = [(.personal, "Your Collections"), (.shared, "From Friends")]
+        let tabs: [(CollectionTab, String)] = [(.personal, String(localized: "collections_your_collections")), (.shared, String(localized: "collections_from_friends"))]
         for (index, (tab, title)) in tabs.enumerated() {
             let button = createTabButton(title: title, tag: index, tab: tab)
             categoryTabStackView.addArrangedSubview(button)
@@ -524,12 +524,12 @@ class SaveToCollectionViewController: UIViewController {
     private func savePlaceToCollection(place: GMSPlace, collection: PlaceCollection) {
         // Check if place is already in the collection
         if collection.places.contains(where: { $0.placeId == place.placeID }) {
-            showAlert(title: "Already Saved", message: "This place is already saved in this collection.")
+            showAlert(title: String(localized: "save_already_saved_title"), message: String(localized: "save_already_saved_message"))
             return
         }
         
         // Show loading indicator
-        let loadingAlert = UIAlertController(title: "Saving...", message: nil, preferredStyle: .alert)
+        let loadingAlert = UIAlertController(title: String(localized: "save_saving"), message: nil, preferredStyle: .alert)
         present(loadingAlert, animated: true)
         
         // Create place data
@@ -592,7 +592,7 @@ class SaveToCollectionViewController: UIViewController {
                     Logger.log("Error fetching members for place save: \(error.localizedDescription)", level: .error, category: "Save")
                     DispatchQueue.main.async {
                         loadingAlert.dismiss(animated: true) {
-                            let messageModal = MessageModalViewController(title: "Error", message: "Failed to save place. Please try again.")
+                            let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "save_failed_place"))
                             self.present(messageModal, animated: true)
                         }
                     }
@@ -612,8 +612,8 @@ class SaveToCollectionViewController: UIViewController {
                             if let error = error {
                                 Logger.log("Error saving place: \(error.localizedDescription)", level: .error, category: "Save")
                                 let messageModal = MessageModalViewController(
-                                    title: "Error",
-                                    message: "Failed to save place. Please try again."
+                                    title: String(localized: "modal_error_title"),
+                                    message: String(localized: "save_failed_place")
                                 )
                                 self.present(messageModal, animated: true)
                             } else {
@@ -634,7 +634,7 @@ class SaveToCollectionViewController: UIViewController {
     private func saveEventToCollection(event: Event, collection: PlaceCollection) {
         
         // Show loading indicator
-        let loadingAlert = UIAlertController(title: "Saving...", message: nil, preferredStyle: .alert)
+        let loadingAlert = UIAlertController(title: String(localized: "save_saving"), message: nil, preferredStyle: .alert)
         present(loadingAlert, animated: true)
         
         // Create event data
@@ -660,7 +660,7 @@ class SaveToCollectionViewController: UIViewController {
                 Logger.log("Error fetching members for event save: \(error.localizedDescription)", level: .error, category: "Save")
                 DispatchQueue.main.async {
                     loadingAlert.dismiss(animated: true) {
-                        let messageModal = MessageModalViewController(title: "Error", message: "Failed to save event. Please try again.")
+                        let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "save_failed_event"))
                         self.present(messageModal, animated: true)
                     }
                 }
@@ -680,8 +680,8 @@ class SaveToCollectionViewController: UIViewController {
                         if let error = error {
                             Logger.log("Error saving event: \(error.localizedDescription)", level: .error, category: "Save")
                             let messageModal = MessageModalViewController(
-                                title: "Error",
-                                message: "Failed to save event. Please try again."
+                                title: String(localized: "modal_error_title"),
+                                message: String(localized: "save_failed_event")
                             )
                             self.present(messageModal, animated: true)
                         } else {

--- a/nose/ViewControllers/Home/Search/SearchViewController.swift
+++ b/nose/ViewControllers/Home/Search/SearchViewController.swift
@@ -52,7 +52,7 @@ final class SearchViewController: UIViewController {
     private lazy var searchTextField: UITextField = {
         let field = UITextField()
         field.translatesAutoresizingMaskIntoConstraints = false
-        field.placeholder = "Search for places or events"
+        field.placeholder = String(localized: "search_placeholder")
         field.font = .systemFont(ofSize: 16)
         field.backgroundColor = .clear
         field.borderStyle = .none

--- a/nose/ViewControllers/Login/LoginViewController.swift
+++ b/nose/ViewControllers/Login/LoginViewController.swift
@@ -11,21 +11,19 @@ final class LoginViewController: UIViewController {
     private lazy var launchLogoImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.image = UIImage(named: "logo")
+        imageView.image = UIImage(named: "logo_dark")
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
     
-    private lazy var sloganLabel: UILabel = {
+    private lazy var appNameLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Map your journey\nStyle your future"
+        label.text = String(localized: "app_name")
         label.textAlignment = .center
-        // set font to gotham
-        let font = UIFont(name: "Gotham-Bold", size: 32) ?? UIFont.systemFont(ofSize: 32, weight: .bold)
+        let font = UIFont(name: "Futura-Medium", size: 66) ?? UIFont.systemFont(ofSize: 66, weight: .medium)
         label.font = font
         label.textColor = .white
-        label.numberOfLines = 0
         label.alpha = 0 // Initially invisible
         return label
     }()
@@ -33,23 +31,61 @@ final class LoginViewController: UIViewController {
     private lazy var appleButton: CustomGlassButton = {
         let button = CustomGlassButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        setupSocialButton(button: button, iconName: "applelogo", title: "Continue with Apple")
+        setupSocialButton(button: button, iconName: "applelogo", title: String(localized: "apple_login"))
         button.addTarget(self, action: #selector(appleButtonTapped), for: .touchUpInside)
         button.alpha = 0 // Initially invisible
         button.accessibilityIdentifier = "continue_with_apple"
-        button.accessibilityLabel = "Continue with Apple"
+        button.accessibilityLabel = String(localized: "apple_login")
         return button
     }()
     
     private lazy var googleButton: CustomGlassButton = {
         let button = CustomGlassButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        setupSocialButton(button: button, iconName: "google_logo", title: "Continue with Google")
+        setupSocialButton(button: button, iconName: "google_logo", title: String(localized: "google_login"))
         button.addTarget(self, action: #selector(googleButtonTapped), for: .touchUpInside)
         button.alpha = 0 // Initially invisible
         button.accessibilityIdentifier = "continue_with_google"
-        button.accessibilityLabel = "Continue with Google"
+        button.accessibilityLabel = String(localized: "google_login")
         return button
+    }()
+    
+    private lazy var termsAndPrivacyTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.delegate = self
+        textView.alpha = 0 // Initially invisible
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.white,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        let base = String(localized: "login_terms_base")
+        let terms = String(localized: "login_terms_of_service")
+        let and = String(localized: "login_terms_and")
+        let privacy = String(localized: "login_privacy_policy")
+        let end = String(localized: "login_terms_end")
+        let full = base + terms + and + privacy + end
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+        let attributed = NSMutableAttributedString(
+            string: full,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 14, weight: .regular),
+                .foregroundColor: UIColor.white,
+                .paragraphStyle: paragraphStyle
+            ]
+        )
+        let termsRange = (full as NSString).range(of: terms)
+        let privacyRange = (full as NSString).range(of: privacy)
+        attributed.addAttribute(.link, value: "nose://terms", range: termsRange)
+        attributed.addAttribute(.link, value: "nose://privacy", range: privacyRange)
+        textView.attributedText = attributed
+        return textView
     }()
     
     private lazy var loadingView: UIView = {
@@ -75,6 +111,7 @@ final class LoginViewController: UIViewController {
     // MARK: - Properties
     private var currentNonce: String?
     private var isLoginMode = false
+    private var loginGradientLayer: CAGradientLayer?
     weak var sceneDelegate: SceneDelegate?
     
     // MARK: - Lifecycle
@@ -86,10 +123,18 @@ final class LoginViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if isLoginMode {
+            loginGradientLayer?.frame = view.bounds
+        }
     }
     
     // MARK: - Setup
@@ -108,57 +153,65 @@ final class LoginViewController: UIViewController {
     }
     
     private func setupLoginStyle() {
-        // Switch to login style (splash background + login UI)
+        // Switch to login style (gradient background + logo above slogan)
         isLoginMode = true
         
-        // Remove launch logo
         launchLogoImageView.removeFromSuperview()
+        view.backgroundColor = .themeLightBlue
         
-        // Setup splash background
-        let backgroundImage = UIImageView(frame: UIScreen.main.bounds)
-        backgroundImage.image = UIImage(named: "splash")
-        
-        if backgroundImage.image == nil {
-            // Set a fallback background color
-            view.backgroundColor = .systemBlue
-        }
-        
-        backgroundImage.contentMode = .scaleAspectFill
-        backgroundImage.clipsToBounds = true
-        view.addSubview(backgroundImage)
-        view.sendSubviewToBack(backgroundImage)
-        
-        // Add login UI elements
-        [sloganLabel, appleButton, googleButton, loadingView].forEach {
-            view.addSubview($0)
-        }
-        
-        // Setup login UI constraints
+        let gradient = CAGradientLayer()
+        gradient.colors = [UIColor.themeLightBlue.cgColor, UIColor.themeBlue.cgColor]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1)
+        gradient.frame = view.bounds
+        view.layer.insertSublayer(gradient, at: 0)
+        loginGradientLayer = gradient
+
+        let bottomStack = UIStackView(arrangedSubviews: [termsAndPrivacyTextView, appleButton, googleButton])
+        bottomStack.axis = .vertical
+        bottomStack.alignment = .center
+        bottomStack.spacing = 8
+        bottomStack.setCustomSpacing(16, after: termsAndPrivacyTextView)
+        bottomStack.translatesAutoresizingMaskIntoConstraints = false
+
+        launchLogoImageView.widthAnchor.constraint(equalToConstant: 72).isActive = true
+        launchLogoImageView.heightAnchor.constraint(equalToConstant: 72).isActive = true
+
+        view.addSubview(launchLogoImageView)
+        view.addSubview(appNameLabel)
+        view.addSubview(bottomStack)
+        view.addSubview(loadingView)
+
+        appNameLabel.font = UIFont(name: "Futura-Medium", size: 66) ?? UIFont.systemFont(ofSize: 66, weight: .medium)
+        appNameLabel.adjustsFontSizeToFitWidth = false
+
+        appleButton.widthAnchor.constraint(equalTo: bottomStack.widthAnchor).isActive = true
+        appleButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        googleButton.widthAnchor.constraint(equalTo: bottomStack.widthAnchor).isActive = true
+        googleButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+
+        launchLogoImageView.alpha = 0
+
         NSLayoutConstraint.activate([
-            sloganLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            sloganLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            sloganLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            sloganLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            
-            appleButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            appleButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            appleButton.heightAnchor.constraint(equalToConstant: 50),
-            appleButton.bottomAnchor.constraint(equalTo: googleButton.topAnchor, constant: -16),
-            
-            googleButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            googleButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            googleButton.heightAnchor.constraint(equalToConstant: 50),
-            googleButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
-            
+            launchLogoImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            launchLogoImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            appNameLabel.leadingAnchor.constraint(equalTo: launchLogoImageView.trailingAnchor, constant: -8),
+            appNameLabel.centerYAnchor.constraint(equalTo: launchLogoImageView.centerYAnchor, constant: -8),
+            termsAndPrivacyTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            termsAndPrivacyTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            bottomStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            bottomStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            bottomStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
             loadingView.topAnchor.constraint(equalTo: view.topAnchor),
             loadingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             loadingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             loadingView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         
-        // Show login UI with animation
         UIView.animate(withDuration: 0.5) {
-            self.sloganLabel.alpha = 1
+            self.launchLogoImageView.alpha = 1
+            self.appNameLabel.alpha = 1
+            self.termsAndPrivacyTextView.alpha = 1
             self.appleButton.alpha = 1
             self.googleButton.alpha = 1
         }
@@ -275,7 +328,7 @@ final class LoginViewController: UIViewController {
             
             if let error = error {
                 Logger.log("Error checking user: \(error.localizedDescription)", level: .error, category: "Login")
-                self.showError(message: "Failed to check user status. Please try again.")
+                self.showError(message: String(localized: "login_error_check_user"))
                 return
             }
             
@@ -304,7 +357,7 @@ final class LoginViewController: UIViewController {
     }
     
     private func showError(message: String) {
-        let messageModal = MessageModalViewController(title: "Error", message: message)
+        let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: message)
         present(messageModal, animated: true)
     }
     
@@ -313,7 +366,7 @@ final class LoginViewController: UIViewController {
         showLoading()
         guard let clientID = FirebaseApp.app()?.options.clientID else {
             hideLoading()
-            showError(message: "Google Sign-In is not properly configured. Please try again.")
+            showError(message: String(localized: "login_error_google_config"))
             return
         }
         
@@ -333,7 +386,7 @@ final class LoginViewController: UIViewController {
                     // User cancelled - don't show error
                     return
                 }
-                self.showError(message: "Failed to sign in with Google: \(error.localizedDescription)")
+                self.showError(message: String(format: String(localized: "login_error_google_signin_format"), error.localizedDescription))
                 return
             }
             
@@ -341,7 +394,7 @@ final class LoginViewController: UIViewController {
                   let idToken = authentication.idToken?.tokenString else {
                 Logger.log("Failed to get Google credentials", level: .error, category: "Login")
                 self.hideLoading()
-                self.showError(message: "Failed to get Google authentication credentials. Please try again.")
+                self.showError(message: String(localized: "login_error_google_credentials"))
                 return
             }
             
@@ -359,7 +412,7 @@ final class LoginViewController: UIViewController {
                 if let error = error {
                     Logger.log("Firebase Sign In error: \(error.localizedDescription)", level: .error, category: "Login")
                     self.hideLoading()
-                    self.showError(message: "Failed to authenticate with Firebase: \(error.localizedDescription)")
+                    self.showError(message: String(format: String(localized: "login_error_firebase_auth_format"), error.localizedDescription))
                     return
                 }
                 
@@ -432,5 +485,30 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
 extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return view.window!
+    }
+}
+
+// MARK: - UITextViewDelegate
+extension LoginViewController: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        if URL.scheme == "nose" {
+            if URL.host == "terms" {
+                let termsVC = ToSViewController()
+                termsVC.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissPresentedPolicyOrTerms))
+                let nav = UINavigationController(rootViewController: termsVC)
+                present(nav, animated: true)
+            } else if URL.host == "privacy" {
+                let privacyVC = PrivacyPolicyViewController()
+                privacyVC.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissPresentedPolicyOrTerms))
+                let nav = UINavigationController(rootViewController: privacyVC)
+                present(nav, animated: true)
+            }
+            return false
+        }
+        return true
+    }
+    
+    @objc private func dismissPresentedPolicyOrTerms() {
+        presentedViewController?.dismiss(animated: true)
     }
 } 

--- a/nose/ViewControllers/Profile/Friend/AddFriendViewController.swift
+++ b/nose/ViewControllers/Profile/Friend/AddFriendViewController.swift
@@ -21,7 +21,7 @@ class AddFriendViewController: UIViewController {
     private lazy var searchBar: UISearchBar = {
         let searchBar = UISearchBar()
         searchBar.translatesAutoresizingMaskIntoConstraints = false
-        searchBar.placeholder = "Search by User ID"
+        searchBar.placeholder = String(localized: "add_friend_search_placeholder")
         searchBar.delegate = self
         searchBar.searchBarStyle = .minimal
         searchBar.autocapitalizationType = .allCharacters
@@ -40,7 +40,7 @@ class AddFriendViewController: UIViewController {
     private lazy var userIdLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Your User ID:"
+        label.text = String(localized: "add_friend_your_user_id")
         label.font = .systemFont(ofSize: 14, weight: .medium)
         label.textColor = .secondaryLabel
         return label
@@ -95,7 +95,7 @@ class AddFriendViewController: UIViewController {
     private lazy var addFriendButton: CustomButton = {
         let button = CustomButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Send Request", for: .normal)
+        button.setTitle(String(localized: "add_friend_send_request"), for: .normal)
         button.addTarget(self, action: #selector(addFriendButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = "add_friend_button"
         button.isHidden = true // Initially hidden
@@ -126,7 +126,7 @@ class AddFriendViewController: UIViewController {
         // set background color
         view.backgroundColor = .firstColor
         
-        title = "Add Friend"
+        title = String(localized: "add_friend_title")
         
         // Configure navigation bar
         navigationController?.navigationBar.tintColor = .label
@@ -248,7 +248,7 @@ class AddFriendViewController: UIViewController {
             searchResults = []
             resultContainer.isHidden = true
             addFriendButton.isHidden = true
-            showAlert(title: "Invalid Input", message: "Please enter a User ID to search")
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_invalid_input"))
             return
         }
         
@@ -258,7 +258,7 @@ class AddFriendViewController: UIViewController {
             searchResults = []
             resultContainer.isHidden = true
             addFriendButton.isHidden = true
-            showAlert(title: "Invalid User ID", message: "User ID must be exactly 10 characters (letters and numbers)")
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_invalid_user_id"))
             return
         }
         
@@ -267,7 +267,7 @@ class AddFriendViewController: UIViewController {
             searchResults = []
             resultContainer.isHidden = true
             addFriendButton.isHidden = true
-            showAlert(title: "Cannot Add Yourself", message: "You cannot add yourself as a friend")
+            showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_cannot_add_yourself"))
             return
         }
         
@@ -288,7 +288,7 @@ class AddFriendViewController: UIViewController {
             if let error = error {
                 self.isSearching = false
                 self.activityIndicator.stopAnimating()
-                self.showAlert(title: "Error", message: "An error occurred while searching. Please try again.")
+                self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_search_error"))
                 return
             }
             
@@ -307,7 +307,7 @@ class AddFriendViewController: UIViewController {
                     self.searchResults = []
                     self.resultContainer.isHidden = true
                     self.addFriendButton.isHidden = true
-                    self.showAlert(title: "User Not Found", message: "No user found with this User ID. Please check the ID and try again.")
+                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_user_not_found"))
                     return
                 }
                 
@@ -322,7 +322,7 @@ class AddFriendViewController: UIViewController {
                             self.searchResults = []
                             self.resultContainer.isHidden = true
                             self.addFriendButton.isHidden = true
-                            self.showAlert(title: "Cannot Add Friend", message: "You have blocked this user. Please unblock them first to add them as a friend.")
+                            self.showAlert(title: String(localized: "add_friend_cannot_add_friend"), message: String(localized: "add_friend_blocked_user"))
                             return
                         }
                         
@@ -334,7 +334,7 @@ class AddFriendViewController: UIViewController {
                                     self.searchResults = []
                                     self.resultContainer.isHidden = true
                                     self.addFriendButton.isHidden = true
-                                    self.showAlert(title: "User Not Found", message: "No user found with this User ID. Please check the ID and try again.")
+                                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_user_not_found"))
                                     return
                                 }
                                 
@@ -346,7 +346,7 @@ class AddFriendViewController: UIViewController {
                                             self.searchResults = []
                                             self.resultContainer.isHidden = true
                                             self.addFriendButton.isHidden = true
-                                            self.showAlert(title: "Already Friends", message: "This user is already in your friends list")
+                                            self.showAlert(title: String(localized: "modal_success_title"), message: String(localized: "add_friend_already_friends"))
                                             return
                                         }
                                         
@@ -359,7 +359,7 @@ class AddFriendViewController: UIViewController {
                                                     self.searchResults = []
                                                     self.resultContainer.isHidden = true
                                                     self.addFriendButton.isHidden = true
-                                                    self.showAlert(title: "Request Pending", message: "This user has already sent you a friend request. Check the Pending tab to approve or reject.")
+                                                    self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_request_pending"))
                                                     return
                                                 }
                                                 // Check for existing sent request to this user
@@ -371,7 +371,7 @@ class AddFriendViewController: UIViewController {
                                                             self.searchResults = []
                                                             self.resultContainer.isHidden = true
                                                             self.addFriendButton.isHidden = true
-                                                            self.showAlert(title: "Request Already Sent", message: "You have already sent a friend request to this user. Check the Pending tab.")
+                                                            self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_request_already_sent"))
                                                             return
                                                         }
                                                         // If not blocked, not friends, and no pending request, show the result
@@ -391,7 +391,7 @@ class AddFriendViewController: UIViewController {
                 self.activityIndicator.stopAnimating()
                 self.resultContainer.isHidden = true
                 self.addFriendButton.isHidden = true
-                self.showAlert(title: "User Not Found", message: "No user found with this User ID. Please check the ID and try again.")
+                self.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_user_not_found"))
             }
         }
     }
@@ -403,14 +403,14 @@ class AddFriendViewController: UIViewController {
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                    self?.showAlert(title: "Request Sent!", message: "Wait for the friend to approve the request.") { _ in
+                    self?.showAlert(title: String(localized: "add_friend_request_sent_title"), message: String(localized: "add_friend_request_sent_message")) { _ in
                         self?.searchBar.text = ""
                         self?.resultContainer.isHidden = true
                         self?.addFriendButton.isHidden = true
                         self?.searchResults = []
                     }
                 case .failure(let error):
-                    self?.showAlert(title: "Error", message: "Failed to send friend request. Please try again.")
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: String(localized: "add_friend_send_request_failed"))
                 }
             }
         }

--- a/nose/ViewControllers/Profile/Friend/FriendsViewController.swift
+++ b/nose/ViewControllers/Profile/Friend/FriendsViewController.swift
@@ -72,7 +72,7 @@ class FriendsViewController: UIViewController {
         // set background color
         view.backgroundColor = .firstColor
         
-        title = "Friends"
+        title = String(localized: "friends_title")
         
         // Configure navigation bar
         navigationController?.navigationBar.tintColor = .label
@@ -195,11 +195,11 @@ class FriendsViewController: UIViewController {
     
     // MARK: - Actions
     // MARK: - Tab Management
-    private static let tabTitles: [(Tab, String)] = [(.friends, "Friends"), (.pending, "Pending"), (.requested, "Requested"), (.blocked, "Blocked")]
+    private static let tabTitles: [(Tab, String)] = [(.friends, "friends_title"), (.pending, "friends_tab_pending"), (.requested, "friends_tab_requested"), (.blocked, "friends_tab_blocked")]
 
     private func setupCategoryTabs() {
-        for (index, (tab, title)) in Self.tabTitles.enumerated() {
-            let button = createTabButton(title: title, tag: index, tab: tab)
+        for (index, (tab, titleKey)) in Self.tabTitles.enumerated() {
+            let button = createTabButton(title: String(localized: String.LocalizationValue(stringLiteral: titleKey)), tag: index, tab: tab)
             switch tab {
             case .friends:
                 button.accessibilityIdentifier = "Friends_tab"
@@ -269,13 +269,13 @@ class FriendsViewController: UIViewController {
     private func emptyMessage(for tab: Tab) -> String {
         switch tab {
         case .friends:
-            return "No friends yet. Share your User ID from Add Friend so others can send you a request."
+            return String(localized: "friends_empty_friends")
         case .pending:
-            return "No pending requests. When someone sends you a friend request, it will appear here."
+            return String(localized: "friends_empty_pending")
         case .requested:
-            return "No requests sent. When you send a friend request from Add Friend, it will appear here until they respond."
+            return String(localized: "friends_empty_requested")
         case .blocked:
-            return "No blocked users."
+            return String(localized: "friends_empty_blocked")
         }
     }
     
@@ -325,7 +325,7 @@ class FriendsViewController: UIViewController {
         nameLabel.textColor = .label
 
         let approve = UIButton(type: .system)
-        approve.setTitle("Approve", for: .normal)
+        approve.setTitle(String(localized: "friends_approve"), for: .normal)
         approve.tag = indexPath.row
         approve.accessibilityIdentifier = "Approve"
         approve.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
@@ -337,7 +337,7 @@ class FriendsViewController: UIViewController {
         approve.addTarget(self, action: #selector(pendingApproveTapped(_:)), for: .touchUpInside)
 
         let reject = UIButton(type: .system)
-        reject.setTitle("Reject", for: .normal)
+        reject.setTitle(String(localized: "friends_reject"), for: .normal)
         reject.tag = indexPath.row
         reject.accessibilityIdentifier = "Reject"
         reject.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
@@ -371,11 +371,11 @@ class FriendsViewController: UIViewController {
     
     private func blockUser(_ user: User) {
         let modal = ConfirmationModalViewController(
-            title: "Block user?",
-            message: "Are you sure you want to block \"\(user.name)\"? You will not be able to share a collection or add them as a friend.",
-            primaryTitle: "Block",
+            title: String(localized: "friends_block_confirm_title"),
+            message: String(format: String(localized: "friends_block_confirm_message_format"), user.name),
+            primaryTitle: String(localized: "friends_block_user"),
             primaryStyle: .destructive,
-            cancelTitle: "Cancel",
+            cancelTitle: String(localized: "modal_cancel"),
             onPrimary: { [weak self] in
                 self?.performBlockUser(user)
             },
@@ -391,9 +391,9 @@ class FriendsViewController: UIViewController {
                 switch result {
                 case .success:
                     self?.loadFriends()
-                    self?.showAlert(title: "Success", message: "User blocked successfully")
+                    self?.showAlert(title: String(localized: "modal_success_title"), message: String(localized: "friends_block_success"))
                 case .failure(let error):
-                    self?.showAlert(title: "Error", message: "Failed to block user: \(error.localizedDescription)")
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: String(format: String(localized: "friends_block_failed_format"), error.localizedDescription))
                 }
             }
         }
@@ -401,10 +401,10 @@ class FriendsViewController: UIViewController {
 
     private func unblockUser(_ user: User) {
         let modal = ConfirmationModalViewController(
-            title: "Unblock user?",
-            message: "\(user.name) will be able to add you as a friend with your User ID.",
-            primaryTitle: "Unblock",
-            cancelTitle: "Cancel",
+            title: String(localized: "friends_unblock_confirm_title"),
+            message: String(format: String(localized: "friends_unblock_confirm_message_format"), user.name),
+            primaryTitle: String(localized: "friends_unblock_user"),
+            cancelTitle: String(localized: "modal_cancel"),
             onPrimary: { [weak self] in
                 self?.performUnblockUser(user)
             },
@@ -420,9 +420,9 @@ class FriendsViewController: UIViewController {
                 switch result {
                 case .success:
                     self?.loadFriends()
-                    self?.showAlert(title: "Success", message: "User unblocked successfully")
+                    self?.showAlert(title: String(localized: "modal_success_title"), message: String(localized: "friends_unblock_success"))
                 case .failure(let error):
-                    self?.showAlert(title: "Error", message: "Failed to unblock user: \(error.localizedDescription)")
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: String(format: String(localized: "friends_unblock_failed_format"), error.localizedDescription))
                 }
             }
         }
@@ -456,7 +456,7 @@ extension FriendsViewController: UITableViewDelegate, UITableViewDataSource {
             let cell = tableView.dequeueReusableCell(withIdentifier: "UserCell", for: indexPath)
             let user = pendingSent[indexPath.row]
             var content = cell.defaultContentConfiguration()
-            content.text = "\(user.name) requested"
+            content.text = String(format: String(localized: "friends_requested"), user.name)
             content.textProperties.color = .label
             content.textProperties.font = .systemFont(ofSize: 17, weight: .medium)
             cell.contentConfiguration = content
@@ -494,10 +494,10 @@ extension FriendsViewController: UITableViewDelegate, UITableViewDataSource {
         guard row < pendingReceived.count else { return }
         let user = pendingReceived[row]
         let modal = ConfirmationModalViewController(
-            title: "Approve request",
-            message: "Add \(user.name) as a friend?",
-            primaryTitle: "Approve",
-            cancelTitle: "Cancel",
+            title: String(localized: "friends_approve_confirm_title"),
+            message: String(format: String(localized: "friends_approve_confirm_message_format"), user.name),
+            primaryTitle: String(localized: "friends_approve"),
+            cancelTitle: String(localized: "modal_cancel"),
             onPrimary: { [weak self] in
                 self?.performApproveFriendRequest(from: user)
             },
@@ -514,9 +514,9 @@ extension FriendsViewController: UITableViewDelegate, UITableViewDataSource {
                 case .success:
                     self?.loadFriends()
                     self?.loadPending()
-                    self?.showAlert(title: "Success", message: "Friend request approved.")
+                    self?.showAlert(title: String(localized: "modal_success_title"), message: String(localized: "friends_approve_success"))
                 case .failure(let error):
-                    self?.showAlert(title: "Error", message: error.localizedDescription)
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: error.localizedDescription)
                 }
             }
         }
@@ -527,11 +527,11 @@ extension FriendsViewController: UITableViewDelegate, UITableViewDataSource {
         guard row < pendingReceived.count else { return }
         let user = pendingReceived[row]
         let modal = ConfirmationModalViewController(
-            title: "Reject request",
-            message: "Reject friend request from \(user.name)?",
-            primaryTitle: "Reject",
+            title: String(localized: "friends_reject_confirm_title"),
+            message: String(format: String(localized: "friends_reject_confirm_message_format"), user.name),
+            primaryTitle: String(localized: "friends_reject"),
             primaryStyle: .default,
-            cancelTitle: "Cancel",
+            cancelTitle: String(localized: "modal_cancel"),
             onPrimary: { [weak self] in
                 self?.performRejectFriendRequest(from: user)
             },
@@ -549,7 +549,7 @@ extension FriendsViewController: UITableViewDelegate, UITableViewDataSource {
                     self?.loadPending()
                     self?.updateEmptyState()
                 case .failure(let error):
-                    self?.showAlert(title: "Error", message: error.localizedDescription)
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: error.localizedDescription)
                 }
             }
         }
@@ -563,15 +563,15 @@ extension FriendsViewController: UITableViewDelegate, UITableViewDataSource {
         let user = currentSegment == Tab.friends.rawValue ? friends[indexPath.row] : blockedUsers[indexPath.row]
         let alert = UIAlertController(title: user.name, message: nil, preferredStyle: .actionSheet)
         if currentSegment == Tab.friends.rawValue {
-            alert.addAction(UIAlertAction(title: "Block User", style: .destructive) { [weak self] _ in
+            alert.addAction(UIAlertAction(title: String(localized: "friends_block_user"), style: .destructive) { [weak self] _ in
                 self?.blockUser(user)
             })
         } else {
-            alert.addAction(UIAlertAction(title: "Unblock User", style: .default) { [weak self] _ in
+            alert.addAction(UIAlertAction(title: String(localized: "friends_unblock_user"), style: .default) { [weak self] _ in
                 self?.unblockUser(user)
             })
         }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: String(localized: "modal_cancel"), style: .cancel))
         present(alert, animated: true)
     }
 }

--- a/nose/ViewControllers/Profile/Settings/About/License/LicensesViewController.swift
+++ b/nose/ViewControllers/Profile/Settings/About/License/LicensesViewController.swift
@@ -23,7 +23,7 @@ class LicensesViewController: UIViewController, UITableViewDelegate, UITableView
     }
 
     private func setupNavigationBar() {
-        navigationItem.title = "Licenses"
+        navigationItem.title = String(localized: "licenses_title")
         self.navigationController?.navigationBar.tintColor = .black
     }
 

--- a/nose/ViewControllers/Profile/Settings/About/PrivacyPolicyViewController.swift
+++ b/nose/ViewControllers/Profile/Settings/About/PrivacyPolicyViewController.swift
@@ -65,7 +65,7 @@ class PrivacyPolicyViewController: UIViewController, WKNavigationDelegate {
         loadingView.isHidden = true
         activityIndicator.stopAnimating()
         // Show error alert
-        let messageModal = MessageModalViewController(title: "Error", message: "Failed to load content. Please try again.")
+        let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "error_failed_load_content"))
         present(messageModal, animated: true)
     }
 }

--- a/nose/ViewControllers/Profile/Settings/About/ToSViewController.swift
+++ b/nose/ViewControllers/Profile/Settings/About/ToSViewController.swift
@@ -65,7 +65,7 @@ class ToSViewController: UIViewController, WKNavigationDelegate {
         loadingView.isHidden = true
         activityIndicator.stopAnimating()
         // Show error alert
-        let messageModal = MessageModalViewController(title: "Error", message: "Failed to load content. Please try again.")
+        let messageModal = MessageModalViewController(title: String(localized: "modal_error_title"), message: String(localized: "error_failed_load_content"))
         present(messageModal, animated: true)
     }
 }

--- a/nose/ViewControllers/Profile/Settings/Account/AccountViewController.swift
+++ b/nose/ViewControllers/Profile/Settings/Account/AccountViewController.swift
@@ -13,6 +13,13 @@ final class AccountViewController: UIViewController {
         case logout = "Logout"
         case deleteAccount = "Delete Account"
         
+        var displayTitle: String {
+            switch self {
+            case .logout: return String(localized: "account_logout_row")
+            case .deleteAccount: return String(localized: "account_delete_account_row")
+            }
+        }
+        
         var isDestructive: Bool {
             switch self {
             case .deleteAccount: return true
@@ -22,15 +29,15 @@ final class AccountViewController: UIViewController {
         
         var alertTitle: String {
             switch self {
-            case .logout: return "Log Out"
-            case .deleteAccount: return "Delete Account"
+            case .logout: return String(localized: "account_logout_confirm_title")
+            case .deleteAccount: return String(localized: "account_delete_confirm_title")
             }
         }
         
         var alertMessage: String {
             switch self {
-            case .logout: return "Are you sure you want to log out?"
-            case .deleteAccount: return "This action is irreversible. Are you sure?"
+            case .logout: return String(localized: "account_logout_confirm_message")
+            case .deleteAccount: return String(localized: "account_delete_confirm_short")
             }
         }
     }
@@ -57,7 +64,7 @@ final class AccountViewController: UIViewController {
     // MARK: - Setup
     private func setupUI() {
         view.backgroundColor = .firstColor
-        title = "Account"
+        title = String(localized: "account_title")
         navigationController?.navigationBar.tintColor = .label
         navigationItem.largeTitleDisplayMode = .never
         
@@ -82,23 +89,23 @@ final class AccountViewController: UIViewController {
     private func handleLogout() {
         do {
             try Auth.auth().signOut()
-            showAlert(title: "Logged Out", message: "You have been successfully logged out.") {
+            showAlert(title: String(localized: "account_logged_out_title"), message: String(localized: "account_logged_out_message")) {
                 self.navigateToLoginScreen()
             }
         } catch {
-            showAlert(title: "Error", message: "Failed to log out: \(error.localizedDescription)")
+            showAlert(title: String(localized: "modal_error_title"), message: String(format: String(localized: "account_logout_failed_format"), error.localizedDescription))
         }
     }
     
     private func deleteAccount() {
         let alert = UIAlertController(
-            title: "Delete Account",
-            message: "Are you sure you want to delete your account? This action cannot be undone.",
+            title: String(localized: "account_delete_confirm_title"),
+            message: String(localized: "account_delete_confirm_message"),
             preferredStyle: .alert
         )
         
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alert.addAction(UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: String(localized: "modal_cancel"), style: .cancel))
+        alert.addAction(UIAlertAction(title: String(localized: "button_delete"), style: .destructive) { [weak self] _ in
             guard let self = self,
                   let currentUserId = Auth.auth().currentUser?.uid else { return }
             
@@ -106,13 +113,13 @@ final class AccountViewController: UIViewController {
                 switch result {
                 case .success:
                     DispatchQueue.main.async {
-                        self.showAlert(title: "Success", message: "Account deleted successfully") { 
+                        self.showAlert(title: String(localized: "modal_success_title"), message: String(localized: "account_deleted_success")) { 
                             self.navigateToLoginScreen()
                         }
                     }
                 case .failure(let error):
                     DispatchQueue.main.async {
-                        self.showAlert(title: "Error", message: "Failed to delete account: \(error.localizedDescription)")
+                        self.showAlert(title: String(localized: "modal_error_title"), message: String(format: String(localized: "account_delete_failed_format"), error.localizedDescription))
                     }
                 }
             }
@@ -136,8 +143,8 @@ final class AccountViewController: UIViewController {
             preferredStyle: .alert
         )
         
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alert.addAction(UIAlertAction(title: "Confirm", style: item.isDestructive ? .destructive : .default) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: String(localized: "modal_cancel"), style: .cancel))
+        alert.addAction(UIAlertAction(title: String(localized: "button_confirm"), style: item.isDestructive ? .destructive : .default) { [weak self] _ in
             switch item {
             case .logout:
                 self?.handleLogout()
@@ -151,7 +158,7 @@ final class AccountViewController: UIViewController {
     
     private func showAlert(title: String, message: String, completion: (() -> Void)? = nil) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default) { _ in completion?() })
+        alert.addAction(UIAlertAction(title: String(localized: "modal_ok"), style: .default) { _ in completion?() })
         present(alert, animated: true)
     }
 }
@@ -167,7 +174,7 @@ extension AccountViewController: UITableViewDelegate, UITableViewDataSource {
         let item = SettingsItem.allCases[indexPath.row]
         
         var content = cell.defaultContentConfiguration()
-        content.text = item.rawValue
+        content.text = item.displayTitle
         content.textProperties.color = item.isDestructive ? .systemRed : .label
         cell.contentConfiguration = content
         

--- a/nose/ViewControllers/Profile/Settings/Account/EditNameViewController.swift
+++ b/nose/ViewControllers/Profile/Settings/Account/EditNameViewController.swift
@@ -18,7 +18,7 @@ final class EditNameViewController: UIViewController {
     private lazy var nameTextField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.placeholder = "Enter your name"
+        textField.placeholder = String(localized: "edit_name_placeholder")
         textField.borderStyle = .none
         textField.backgroundColor = .secondColor
         textField.layer.cornerRadius = 8
@@ -43,14 +43,14 @@ final class EditNameViewController: UIViewController {
         label.textAlignment = .right
         label.font = .systemFont(ofSize: 12)
         label.textColor = .gray
-        label.text = "0/\(Constants.maxNameLength)"
+        label.text = String(format: String(localized: "edit_name_char_count"), 0, Constants.maxNameLength)
         return label
     }()
     
     private lazy var saveButton: CustomButton = {
         let button = CustomButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Save", for: .normal)
+        button.setTitle(String(localized: "button_save"), for: .normal)
         button.style = .themeBlue
         button.size = .large
         button.isPerfectlyRounded = true
@@ -68,7 +68,7 @@ final class EditNameViewController: UIViewController {
     // MARK: - Setup
     private func setupUI() {
         view.backgroundColor = .firstColor
-        title = "Edit Name"
+        title = String(localized: "edit_name_title")
         navigationController?.navigationBar.tintColor = .label
         navigationItem.largeTitleDisplayMode = .never
         
@@ -105,7 +105,7 @@ final class EditNameViewController: UIViewController {
         
         UserManager.shared.getUser(id: currentUserId) { [weak self] user, error in
             if let error = error {
-                self?.showAlert(title: "Error", message: "Failed to load user data: \(error.localizedDescription)")
+                self?.showAlert(title: String(localized: "modal_error_title"), message: String(format: String(localized: "edit_name_failed_load"), error.localizedDescription))
                 return
             }
             
@@ -126,7 +126,7 @@ final class EditNameViewController: UIViewController {
     
     private func updateCharacterCount(for text: String?) {
         let count = text?.count ?? 0
-        characterCountLabel.text = "\(count)/\(Constants.maxNameLength)"
+        characterCountLabel.text = String(format: String(localized: "edit_name_char_count"), count, Constants.maxNameLength)
         
         // Update label color based on character count
         if count > Constants.maxNameLength {
@@ -141,18 +141,18 @@ final class EditNameViewController: UIViewController {
     @objc private func saveButtonTapped() {
         guard let newName = nameTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
               !newName.isEmpty else {
-            showAlert(title: "Invalid Name", message: "Please enter a valid name")
+            showAlert(title: String(localized: "edit_name_invalid_title"), message: String(localized: "edit_name_enter_valid"))
             return
         }
         
         // Validate name length
         if newName.count < Constants.minNameLength {
-            showAlert(title: "Invalid Name", message: "Name must be at least \(Constants.minNameLength) characters long")
+            showAlert(title: String(localized: "edit_name_invalid_title"), message: String(format: String(localized: "edit_name_min_length_format"), Constants.minNameLength))
             return
         }
         
         if newName.count > Constants.maxNameLength {
-            showAlert(title: "Invalid Name", message: "Name must be no more than \(Constants.maxNameLength) characters long")
+            showAlert(title: String(localized: "edit_name_invalid_title"), message: String(format: String(localized: "edit_name_max_length_format"), Constants.maxNameLength))
             return
         }
         
@@ -162,13 +162,13 @@ final class EditNameViewController: UIViewController {
             switch result {
             case .success:
                 DispatchQueue.main.async {
-                    self?.showAlert(title: "Success", message: "Name updated successfully") { _ in
+                    self?.showAlert(title: String(localized: "edit_name_success_title"), message: String(localized: "edit_name_success_message")) { _ in
                         self?.navigationController?.popViewController(animated: true)
                     }
                 }
             case .failure(let error):
                 DispatchQueue.main.async {
-                    self?.showAlert(title: "Error", message: "Failed to update name: \(error.localizedDescription)")
+                    self?.showAlert(title: String(localized: "modal_error_title"), message: String(format: String(localized: "edit_name_failed_update_format"), error.localizedDescription))
                 }
             }
         }

--- a/nose/ViewControllers/Profile/Settings/ProfileImageViewController.swift
+++ b/nose/ViewControllers/Profile/Settings/ProfileImageViewController.swift
@@ -86,7 +86,7 @@ class ProfileImageViewController: UIViewController {
     private lazy var emptyStateLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "No avatar images found"
+        label.text = String(localized: "profile_no_avatar_found")
         label.font = .systemFont(ofSize: 16)
         label.textColor = .secondaryLabel
         label.textAlignment = .center
@@ -103,7 +103,7 @@ class ProfileImageViewController: UIViewController {
     }
     
     private func setupNavigationBar() {
-        title = "Select Profile Picture"
+        title = String(localized: "profile_select_picture_title")
         
         // Add Save button
         let saveButton = UIBarButtonItem(title: "Save", style: .done, target: self, action: #selector(saveButtonTapped))

--- a/nose/ViewControllers/Profile/Settings/SettingsViewController.swift
+++ b/nose/ViewControllers/Profile/Settings/SettingsViewController.swift
@@ -5,11 +5,11 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
 
     let tableView = UITableView()
 
-    // Define setting categories and items
+    // Define setting categories and items (keys for localization)
     var settingsData: [(category: String, items: [String])] = [
-        ("Profile", ["Name", "Account"]),
-        ("Friends", ["Friend List", "Add Friend"]),
-        ("About", ["Privacy Policy", "Terms of Service", "App Version", "Licenses"])
+        ("settings_profile", ["settings_name", "settings_account"]),
+        ("settings_friends", ["settings_friend_list", "settings_add_friend"]),
+        ("settings_about", ["settings_privacy_policy", "settings_terms_of_service", "settings_app_version", "settings_licenses"])
     ]
 
     override func viewDidLoad() {
@@ -29,7 +29,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
     }
 
     private func setupNavigationBar() {
-        navigationItem.title = "Settings"
+        navigationItem.title = String(localized: "settings_title")
         self.navigationController?.navigationBar.tintColor = .fourthColor
         
         // Remove any existing right bar button items
@@ -69,9 +69,9 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         let item = settingsData[indexPath.section].items[indexPath.row]
         let cell: UITableViewCell
 
-        if item == "App Version" {
+        if item == "settings_app_version" {
             cell = UITableViewCell(style: .value1, reuseIdentifier: "versionCell")
-            cell.textLabel?.text = item
+            cell.textLabel?.text = String(localized: String.LocalizationValue(stringLiteral: item))
             
             // Get version and build number
             let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
@@ -91,7 +91,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             cell.selectionStyle = .none  // Disable selection for app version cell
         } else {
             cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-            cell.textLabel?.text = item
+            cell.textLabel?.text = String(localized: String.LocalizationValue(stringLiteral: item))
             cell.accessoryType = .disclosureIndicator  // Add arrow to indicate navigation
         }
 
@@ -101,7 +101,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
 
     // Set section headers
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return settingsData[section].category
+        return String(localized: String.LocalizationValue(stringLiteral: settingsData[section].category))
     }
 
     // Handle selection of a setting option
@@ -110,25 +110,25 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
 
         let selectedSetting = settingsData[indexPath.section].items[indexPath.row]
 
-        if selectedSetting == "Name" {
+        if selectedSetting == "settings_name" {
             let nameupdateVC = EditNameViewController()
             navigationController?.pushViewController(nameupdateVC, animated: true)
-        } else if selectedSetting == "Account" {
+        } else if selectedSetting == "settings_account" {
             let accountVC = AccountViewController()
             navigationController?.pushViewController(accountVC, animated: true)
-        } else if selectedSetting == "Friend List" {
+        } else if selectedSetting == "settings_friend_list" {
             let friendsVC = FriendsViewController()
             navigationController?.pushViewController(friendsVC, animated: true)
-        } else if selectedSetting == "Add Friend" {
+        } else if selectedSetting == "settings_add_friend" {
             let addFriendVC = AddFriendViewController()
             navigationController?.pushViewController(addFriendVC, animated: true)
-        } else if selectedSetting == "Privacy Policy" {
+        } else if selectedSetting == "settings_privacy_policy" {
             let privacypolicyVC = PrivacyPolicyViewController()
             navigationController?.pushViewController(privacypolicyVC, animated: true)
-        } else if selectedSetting == "Terms of Service" {
+        } else if selectedSetting == "settings_terms_of_service" {
             let termsVC = ToSViewController()
             navigationController?.pushViewController(termsVC, animated: true)
-        } else if selectedSetting == "Licenses" {
+        } else if selectedSetting == "settings_licenses" {
             let licensesVC = LicensesViewController()
             navigationController?.pushViewController(licensesVC, animated: true)
         }

--- a/nose/ViewControllers/Setup/NameRegistrationViewController.swift
+++ b/nose/ViewControllers/Setup/NameRegistrationViewController.swift
@@ -16,7 +16,7 @@ final class NameRegistrationViewController: UIViewController {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "What should we call you?"
+        label.text = String(localized: "name_registration_prompt")
         label.textAlignment = .left
         label.font = .systemFont(ofSize: 24, weight: .bold)
         label.textColor = .black
@@ -26,7 +26,7 @@ final class NameRegistrationViewController: UIViewController {
     private lazy var nameTextField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.placeholder = "Enter your name"
+        textField.placeholder = String(localized: "edit_name_placeholder")
         textField.borderStyle = .none
         textField.backgroundColor = .secondColor
         textField.layer.cornerRadius = 8
@@ -51,7 +51,7 @@ final class NameRegistrationViewController: UIViewController {
         label.textAlignment = .right
         label.font = .systemFont(ofSize: 12)
         label.textColor = .gray
-        label.text = "0/\(Constants.maxNameLength)"
+        label.text = String(format: String(localized: "edit_name_char_count"), 0, Constants.maxNameLength)
         return label
     }()
     
@@ -119,7 +119,7 @@ final class NameRegistrationViewController: UIViewController {
     // MARK: - Actions
     @objc private func textFieldDidChange(_ textField: UITextField) {
         let count = textField.text?.count ?? 0
-        characterCountLabel.text = "\(count)/\(Constants.maxNameLength)"
+        characterCountLabel.text = String(format: String(localized: "edit_name_char_count"), count, Constants.maxNameLength)
         characterCountLabel.textColor = count > Constants.maxNameLength ? .systemRed :
                                       count < Constants.minNameLength ? .systemOrange : .gray
     }

--- a/nose/ViewControllers/UnityAvatar/FloatingUIController.swift
+++ b/nose/ViewControllers/UnityAvatar/FloatingUIController.swift
@@ -466,7 +466,7 @@ class FloatingUIController: UIViewController {
         colorSheetView = sheet
 
         let title = UILabel()
-        title.text = "Colors"
+        title.text = String(localized: "unity_colors")
         title.font = .systemFont(ofSize: 16, weight: .semibold)
         title.translatesAutoresizingMaskIntoConstraints = false
         sheet.addSubview(title)
@@ -923,7 +923,7 @@ class FloatingUIController: UIViewController {
             ])
 
             let noAssetsLabel = UILabel()
-            noAssetsLabel.text = "No assets available"
+            noAssetsLabel.text = String(localized: "unity_no_assets")
             noAssetsLabel.textAlignment = .center
             noAssetsLabel.textColor = .fourthColor
             noAssetsLabel.font = .systemFont(ofSize: 16, weight: .medium)


### PR DESCRIPTION
## Summary
Adds full Japanese localization so the app is available in Japanese alongside English.

## Changes
- **Info.plist**: Added `CFBundleLocalizations` with `en` and `ja`.
- **InfoPlist.xcstrings**: Localized `CFBundleDisplayName`, location usage descriptions (en/ja).
- **Localizable.xcstrings**: Added many keys for en/ja across:
  - Login, toasts, modals, common buttons (OK, Cancel, Save, etc.)
  - Settings, Friends, Add Friend, Account, Edit Name
  - Collections (save, edit, new, share, empty states), Place detail, Search, Home
  - Events (create/edit, validation, manage, detail)
  - DeepLinkManager alerts and toasts
  - Profile image, Licenses, Privacy/ToS, Name registration, Unity, Place cell
- **Code**: Replaced hardcoded user-facing strings with `String(localized: "key")` (and `String(format: String(localized: "key"), ...)` where needed) across ViewControllers, Components, and DeepLinkManager.
- **Fixes**: Used `String.LocalizationValue(stringLiteral: ...)` where the key is a variable (Settings, Friends).
- **Search**: Placeholder set to "Search for places" / "スポットを検索" (no events wording).

## Testing
- Verify app shows in Japanese when device language is Japanese.
- Spot-check key screens (Login, Home, Collections, Settings, Friends, Events) in both en and ja.

Made with [Cursor](https://cursor.com)