### PR TITLE
ci: Add Maestro E2E workflow to main for PR checks

### DIFF
--- a/.github/workflows/maestro-e2e-reusable.yml
+++ b/.github/workflows/maestro-e2e-reusable.yml
@@ -1,0 +1,119 @@
+# Reusable Maestro E2E workflow: build iOS app and run Maestro tests.
+# Runs on a self-hosted macOS runner where Google test accounts are already
+# cached in the simulator (required for Google Sign-In picker flows).
+#
+# Required secrets: CI_ENV_FILE, GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST,
+# GOOGLE_SERVICE_INFO_STAGING_PLIST, GOOGLE_SERVICE_INFO_PRODUCTION_PLIST,
+# USER_A_EMAIL, USER_A_NAME, USER_B_EMAIL, USER_B_NAME.
+name: Maestro E2E
+
+on:
+  workflow_call:
+
+jobs:
+  maestro-e2e:
+    name: Maestro E2E
+    runs-on: [self-hosted, macOS]
+    env:
+      JAVA_HOME: /opt/homebrew/opt/openjdk@17
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Patch project to exclude Unity
+        run: bash scripts/patch_project_exclude_unity.sh
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate config from env (xcconfig, Config.plist)
+        env:
+          CI_ENV_FILE: ${{ secrets.CI_ENV_FILE }}
+        run: |
+          if [ -z "$CI_ENV_FILE" ]; then
+            echo "::error::Secret CI_ENV_FILE is not set."
+            exit 1
+          fi
+          printf '%s' "$CI_ENV_FILE" > .env
+          node scripts/generate_config_from_env.js
+
+      - name: Write Firebase GoogleService-Info plists
+        env:
+          GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST }}
+          GOOGLE_SERVICE_INFO_STAGING_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_STAGING_PLIST }}
+          GOOGLE_SERVICE_INFO_PRODUCTION_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PRODUCTION_PLIST }}
+        run: |
+          mkdir -p FirebaseConfig
+          printf '%s' "$GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST" > FirebaseConfig/GoogleService-Info-Development.plist
+          printf '%s' "$GOOGLE_SERVICE_INFO_STAGING_PLIST" > FirebaseConfig/GoogleService-Info-Staging.plist
+          printf '%s' "$GOOGLE_SERVICE_INFO_PRODUCTION_PLIST" > FirebaseConfig/GoogleService-Info-Production.plist
+          for f in FirebaseConfig/GoogleService-Info-Development.plist FirebaseConfig/GoogleService-Info-Staging.plist FirebaseConfig/GoogleService-Info-Production.plist; do
+            [ -s "$f" ] || { echo "::error::Missing or empty plist: $f"; exit 1; }
+          done
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+
+      - name: Install CocoaPods dependencies
+        run: bundle exec pod install
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Build iOS app
+        run: |
+          xcodebuild build \
+            -workspace nose.xcworkspace \
+            -scheme nose-e2e \
+            -configuration E2E \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
+            -derivedDataPath ./builds
+
+      - name: Boot simulator
+        run: xcrun simctl boot "iPhone 16 Pro" || true
+
+      - name: Install app on simulator
+        run: xcrun simctl install booted ./builds/Build/Products/E2E-iphonesimulator/nose.app
+
+      - name: Ensure Maestro installed
+        run: |
+          if command -v maestro &>/dev/null || [ -x "$HOME/.maestro/bin/maestro" ]; then
+            echo "Maestro is already installed."
+          else
+            echo "Installing Maestro..."
+            curl -fsSL "https://get.maestro.mobile.dev" | bash
+          fi
+
+      - name: Run Maestro tests
+        env:
+          USER_A_EMAIL: ${{ secrets.USER_A_EMAIL }}
+          USER_A_NAME: ${{ secrets.USER_A_NAME }}
+          USER_B_EMAIL: ${{ secrets.USER_B_EMAIL }}
+          USER_B_NAME: ${{ secrets.USER_B_NAME }}
+        run: |
+          export PATH="$HOME/.maestro/bin:$PATH"
+          maestro test \
+            --format junit \
+            --output ./maestro-report \
+            --env USER_A_EMAIL="$USER_A_EMAIL" \
+            --env USER_A_NAME="$USER_A_NAME" \
+            --env USER_B_EMAIL="$USER_B_EMAIL" \
+            --env USER_B_NAME="$USER_B_NAME" \
+            .maestro/
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-report
+          path: maestro-report/
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: xcrun simctl shutdown "iPhone 16 Pro" || true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,8 @@
-# PR gate: run E2E (and optionally lint) before merge to staging.
-# Branch protection should require "E2E" (and "lint" if added) to pass.
+# PR gate: run Maestro E2E before merge to staging.
+# Branch protection should require "maestro-e2e / Maestro E2E" to pass.
 #
-# Required secrets for build: CI_ENV_FILE (.env contents), and optionally
-# GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST, _STAGING_PLIST, _PRODUCTION_PLIST (Firebase plist contents).
-# Unity is excluded from E2E builds via EXCLUDE_UNITY flag + pbxproj patching.
+# If branch protection currently requires the old "E2E" check, update it to
+# require "maestro-e2e / Maestro E2E" instead.
 name: PR Checks
 
 on:
@@ -11,136 +10,6 @@ on:
     branches: [staging]
 
 jobs:
-  e2e:
-    name: E2E
-    runs-on: macos-14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Patch project to exclude Unity
-        run: bash scripts/patch_project_exclude_unity.sh
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Generate config from env (xcconfig, Config.plist)
-        env:
-          CI_ENV_FILE: ${{ secrets.CI_ENV_FILE }}
-        run: |
-          if [ -z "$CI_ENV_FILE" ]; then
-            echo "::error::Secret CI_ENV_FILE is not set. Add a repo secret with the contents of .env (or a CI-safe .env) so scripts/generate_config_from_env.js can run."
-            exit 1
-          fi
-          printf '%s' "$CI_ENV_FILE" > .env
-          node scripts/generate_config_from_env.js
-
-      - name: Write Firebase GoogleService-Info plists
-        env:
-          GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST }}
-          GOOGLE_SERVICE_INFO_STAGING_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_STAGING_PLIST }}
-          GOOGLE_SERVICE_INFO_PRODUCTION_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PRODUCTION_PLIST }}
-        run: |
-          mkdir -p FirebaseConfig
-          printf '%s' "$GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST" > FirebaseConfig/GoogleService-Info-Development.plist
-          printf '%s' "$GOOGLE_SERVICE_INFO_STAGING_PLIST" > FirebaseConfig/GoogleService-Info-Staging.plist
-          printf '%s' "$GOOGLE_SERVICE_INFO_PRODUCTION_PLIST" > FirebaseConfig/GoogleService-Info-Production.plist
-          for f in FirebaseConfig/GoogleService-Info-Development.plist FirebaseConfig/GoogleService-Info-Staging.plist FirebaseConfig/GoogleService-Info-Production.plist; do
-            [ -s "$f" ] || { echo "::error::Missing or empty plist: $f. Add secrets GOOGLE_SERVICE_INFO_DEVELOPMENT_PLIST, _STAGING_PLIST, _PRODUCTION_PLIST (contents of each Firebase plist)."; exit 1; }
-          done
-
-      - name: Write Appium config
-        env:
-          APPIUM_CONFIG_PY: ${{ secrets.APPIUM_CONFIG_PY }}
-        run: |
-          if [ -z "$APPIUM_CONFIG_PY" ]; then
-            echo "::error::Secret APPIUM_CONFIG_PY is not set. Add a repo secret with the contents of AppiumTests/utils/config.py."
-            exit 1
-          fi
-          printf '%s' "$APPIUM_CONFIG_PY" > AppiumTests/utils/config.py
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r AppiumTests/requirements.txt
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.2
-          bundler-cache: true
-
-      - name: Install CocoaPods dependencies
-        run: bundle exec pod install
-
-      - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
-
-      - name: Build iOS app for testing
-        run: |
-          xcodebuild clean -workspace nose.xcworkspace -scheme nose-staging
-          xcodebuild build \
-            -workspace nose.xcworkspace \
-            -scheme nose-staging \
-            -configuration Development \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
-            -derivedDataPath ./builds \
-            GCC_PREPROCESSOR_DEFINITIONS='$(inherited) EXCLUDE_UNITY=1'
-
-      - name: Start Appium server
-        run: |
-          npm install -g appium
-          appium driver install xcuitest
-          appium --log appium.log &
-          sleep 15
-          curl -f http://localhost:4723/status || (echo "Appium server failed to start" && cat appium.log && exit 1)
-
-      - name: Start iOS Simulator
-        run: |
-          xcrun simctl boot "iPhone 16 Pro"
-          sleep 15
-          xcrun simctl list devices | grep "iPhone 16 Pro" | grep "Booted" || (echo "Simulator failed to boot" && exit 1)
-
-      - name: Install app on simulator
-        run: |
-          xcrun simctl install booted ./builds/Build/Products/Development-iphonesimulator/nose.app
-
-      - name: Update app path in driver setup
-        run: |
-          APP_PATH="./builds/Build/Products/Development-iphonesimulator/nose.app"
-          sed -i '' "s|app = '.*'|app = '$APP_PATH'|g" AppiumTests/utils/driver_setup.py
-
-      - name: Run Appium tests
-        run: |
-          cd AppiumTests
-          mkdir -p test-results logs
-          python test_runner.py 2>&1 | tee logs/test_output.log
-          exit_code=${PIPESTATUS[0]}
-          echo "Test execution completed with exit code: $exit_code" > test-results/summary.txt
-          exit $exit_code
-        env:
-          PYTHONPATH: ${{ github.workspace }}/AppiumTests
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: appium-test-results
-          path: |
-            AppiumTests/test-results/
-            AppiumTests/logs/
-            appium.log
-          retention-days: 7
-
-      - name: Cleanup
-        if: always()
-        run: |
-          pkill -f appium || true
-          xcrun simctl shutdown "iPhone 16 Pro" || true
+  maestro-e2e:
+    uses: ./.github/workflows/maestro-e2e-reusable.yml
+    secrets: inherit


### PR DESCRIPTION
## 目的
PR で staging 向けに Maestro E2E が走るようにする。GitHub Actions は **デフォルトブランチ（main）** のワークフロー定義を使うため、main に Maestro 用ワークフローを入れる必要がある。

## 変更内容
- **pr-checks.yml**: Appium ベースの E2E をやめ、Maestro の再利用ワークフロー呼び出しに変更
- **maestro-e2e-reusable.yml**: 新規追加（セルフホスト macOS、nose-e2e スキーム、Maestro 実行）

## マージ後
- staging 向け PR を開く／更新すると「PR Checks」→「Maestro E2E」ジョブが実行される
- ブランチ保護で「maestro-e2e / Maestro E2E」を必須にしている場合はそのまま利用可能

Made with [Cursor](https://cursor.com)