### PR TITLE
fix: category tab corner radius flickering

### DIFF
--- a/nose/ViewControllers/UnityAvatar/FloatingUIController.swift
+++ b/nose/ViewControllers/UnityAvatar/FloatingUIController.swift
@@ -791,7 +791,7 @@ class FloatingUIController: UIViewController {
         button.setTitleColor(.black, for: .normal)
         // Set default background to secondColor
         button.backgroundColor = .secondColor
-        button.layer.cornerRadius = isParent ? 16 : 12
+        button.clipsToBounds = true
         button.layer.borderWidth = 0
         button.layer.borderColor = UIColor.clear.cgColor
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -867,7 +867,6 @@ class FloatingUIController: UIViewController {
                 // Inactive tab: secondColor background with black text
                 button.backgroundColor = isSelected ? .fourthColor : .secondColor
                 button.setTitleColor(isSelected ? .white : .black, for: .normal)
-                button.layer.cornerRadius = 16
             }
         }
         for (index, subview) in childCategoryStackView.arrangedSubviews.enumerated() {
@@ -879,7 +878,6 @@ class FloatingUIController: UIViewController {
                 // Inactive tab: secondColor background with black text
                 button.backgroundColor = isSelected ? .fourthColor : .secondColor
                 button.setTitleColor(isSelected ? .white : .black, for: .normal)
-                button.layer.cornerRadius = 12
             }
         }
     }


### PR DESCRIPTION
## Summary
- アバター編集画面のカテゴリタブで rounded corner がチラつく問題を修正
- `viewDidLayoutSubviews()` (pill型) と `updateCategoryButtonStates()` (固定値) の両方で `cornerRadius` を設定していたのが原因
- `cornerRadius` の設定を `viewDidLayoutSubviews()` に一元化

## Test plan
- [ ] アバター編集画面でカテゴリタブを切り替え、角丸がチラつかないことを確認
- [ ] 親カテゴリ・子カテゴリ両方で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)